### PR TITLE
Tweak ReflectiveConfigCreator to be more forgiving when scanning for fields

### DIFF
--- a/src/main/java/org/quiltmc/config/impl/builders/ReflectiveConfigCreator.java
+++ b/src/main/java/org/quiltmc/config/impl/builders/ReflectiveConfigCreator.java
@@ -38,11 +38,13 @@ public class ReflectiveConfigCreator<C> implements Config.Creator {
 	}
 
 	private void createField(Config.SectionBuilder builder, Object object, Field field) throws IllegalAccessException {
-		if (!Modifier.isFinal(field.getModifiers())) {
-			throw new ConfigFieldException("Field '" + field.getType().getName() + ':' + field.getName() + "' is not final");
-		}
-
 		if (!Modifier.isStatic(field.getModifiers()) && !Modifier.isTransient(field.getModifiers())) {
+			if (!Modifier.isFinal(field.getModifiers())) {
+				throw new ConfigFieldException("Field '" + field.getType().getName() + ':' + field.getName() + "' is not final");
+			}
+			if (!Modifier.isPublic(field.getModifiers())) {
+				field.setAccessible(true);
+			}
 			Object defaultValue = field.get(object);
 
 			if (ConfigUtils.isValidValue(defaultValue)) {


### PR DESCRIPTION
This allows static or transient fields to *not* be final, and also allows configured fields to be private - which might be useful if the config class has some other way to expose the config value to the rest of the mod.

I'm not sure if the "is public" check is necessary, since we probably don't care if we leave `Field.isAccessible()` on true unnecessarily.