### PR TITLE
Split multiline comments

### DIFF
--- a/src/main/java/org/quiltmc/config/api/annotations/Comment.java
+++ b/src/main/java/org/quiltmc/config/api/annotations/Comment.java
@@ -51,7 +51,11 @@ public @interface Comment {
 		private final List<String> comments = new ArrayList<>(0);
 
 		public void add(String... comments) {
-			this.comments.addAll(Arrays.asList(comments));
+			for (String comment : comments) {
+				for (String c : comment.split('\n')) {
+					this.comments.add(c);
+				}
+			}
 		}
 
 		@Override

--- a/src/main/java/org/quiltmc/config/api/annotations/Comment.java
+++ b/src/main/java/org/quiltmc/config/api/annotations/Comment.java
@@ -52,9 +52,7 @@ public @interface Comment {
 
 		public void add(String... comments) {
 			for (String comment : comments) {
-				for (String c : comment.split('\n')) {
-					this.comments.add(c);
-				}
+				this.comments.addAll(Arrays.asList(comment.split("\n")));
 			}
 		}
 


### PR DESCRIPTION
Renders https://github.com/QuiltMC/quilt-loader/pull/92 obsolete by splitting up multiline comments when added to the metadata builder.