### PR TITLE
Add type wrapper

### DIFF
--- a/src/main/java/org/quiltmc/config/api/Config.java
+++ b/src/main/java/org/quiltmc/config/api/Config.java
@@ -429,6 +429,14 @@ public interface Config extends MetadataContainer {
 		 * @return this
 		 */
 		Builder format(String format);
+
+		/**
+		 * Adds a typewrapper to this config.
+		 *
+		 * @return this
+		 *
+		 */
+		<K,V> Builder addTypeWrapper(Class<V> wrapperFor, ConfigTypeWrapper<K, V> wrapper);
 	}
 
 	@ApiStatus.NonExtendable

--- a/src/main/java/org/quiltmc/config/api/ConfigTypeWrapper.java
+++ b/src/main/java/org/quiltmc/config/api/ConfigTypeWrapper.java
@@ -1,0 +1,14 @@
+package org.quiltmc.config.api;
+
+public interface ConfigTypeWrapper<T, V> {
+
+    /**
+     * @return a new instance of this class created from the given representation
+     */
+    V convertFrom(T representation);
+
+    /**
+     * @return some representation value for serializationw
+     */
+    T getRepresentation(V value);
+}

--- a/src/main/java/org/quiltmc/config/api/MarshallingUtils.java
+++ b/src/main/java/org/quiltmc/config/api/MarshallingUtils.java
@@ -86,7 +86,7 @@ public final class MarshallingUtils {
 
 	@Deprecated
 	public static <M, L> Object coerce(Object object, Object to, ValueMapCreator<M> creator) {
-		return coerce(object, to, creator, new HashMap<>();
+		return coerce(object, to, creator, new HashMap<>());
 	}
 
 	public interface ValueMapCreator<M> {

--- a/src/main/java/org/quiltmc/config/api/values/TrackedValue.java
+++ b/src/main/java/org/quiltmc/config/api/values/TrackedValue.java
@@ -117,8 +117,6 @@ public interface TrackedValue<T> extends ValueTreeNode {
 	 * @return a new {@link TrackedValue}
 	 */
 	static <T> TrackedValue<T> create(@NotNull T defaultValue, String key0, String... keys) {
-		ConfigUtils.assertValueType(defaultValue);
-
 		return new TrackedValueImpl<>(new ValueKeyImpl(key0, keys), defaultValue, new LinkedHashMap<>(0), new ArrayList<>(0), new ArrayList<>(0));
 	}
 

--- a/src/main/java/org/quiltmc/config/api/values/ValueList.java
+++ b/src/main/java/org/quiltmc/config/api/values/ValueList.java
@@ -27,8 +27,6 @@ import java.util.List;
 public interface ValueList<T> extends List<T>, CompoundConfigValue<T> {
 	@SafeVarargs
 	static <T> ValueList<T> create(T defaultValue, T... values) {
-		ConfigUtils.assertValueType(defaultValue);
-
 		return new ValueListImpl<>(defaultValue, new ArrayList<>(Arrays.asList(values)));
 	}
 }

--- a/src/main/java/org/quiltmc/config/api/values/ValueMap.java
+++ b/src/main/java/org/quiltmc/config/api/values/ValueMap.java
@@ -24,7 +24,6 @@ import java.util.Map;
 @ApiStatus.NonExtendable
 public interface ValueMap<T> extends Iterable<Map.Entry<String, T>>, Map<String, T>, CompoundConfigValue<T> {
 	static <T> Builder<T> builder(T defaultValue) {
-		ConfigUtils.assertValueType(defaultValue);
 
 		return new ValueMapBuilderImpl<>(defaultValue);
 	}

--- a/src/main/java/org/quiltmc/config/impl/ConfigImpl.java
+++ b/src/main/java/org/quiltmc/config/impl/ConfigImpl.java
@@ -41,7 +41,9 @@ public final class ConfigImpl extends AbstractMetadataContainer implements Confi
 	private final Trie values;
 	private final String defaultFileType;
 
-	public ConfigImpl(ConfigEnvironment environment, String id, Path path, Map<MetadataType<?, ?>, Object> metadata, String family, List<UpdateCallback> callbacks, Trie values, String defaultFileType) {
+	private final Map<Class<?>, ConfigTypeWrapper<?,?>> configTypeWrapper;
+
+	public ConfigImpl(ConfigEnvironment environment, String id, Path path, Map<MetadataType<?, ?>, Object> metadata, String family, List<UpdateCallback> callbacks, Trie values, String defaultFileType, Map<Class<?>, ConfigTypeWrapper<?,?>> configTypeWrapper) {
 		super(metadata);
 		this.environment = environment;
 		this.family = family;
@@ -50,6 +52,7 @@ public final class ConfigImpl extends AbstractMetadataContainer implements Confi
 		this.callbacks = callbacks;
 		this.values = values;
 		this.defaultFileType = defaultFileType;
+		this.configTypeWrapper = configTypeWrapper;
 	}
 
 	@Override
@@ -82,6 +85,10 @@ public final class ConfigImpl extends AbstractMetadataContainer implements Confi
 
 	private Path getPath() {
 		return this.environment.getSaveDir().resolve(this.family).resolve(this.path).resolve(this.id + "." + this.environment.getSerializer(this.defaultFileType).getFileExtension());
+	}
+
+	public Map<Class<?>, ConfigTypeWrapper<?, ?>> getTypeWrapper() {
+		return configTypeWrapper;
 	}
 
 	@Override

--- a/src/main/java/org/quiltmc/config/impl/builders/ReflectiveConfigCreator.java
+++ b/src/main/java/org/quiltmc/config/impl/builders/ReflectiveConfigCreator.java
@@ -28,6 +28,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.HashMap;
 
 public class ReflectiveConfigCreator<C> implements Config.Creator {
 	private final Class<C> creatorClass;
@@ -47,7 +48,7 @@ public class ReflectiveConfigCreator<C> implements Config.Creator {
 			}
 			Object defaultValue = field.get(object);
 
-			if (ConfigUtils.isValidValue(defaultValue)) {
+			if (ConfigUtils.isValidValue(defaultValue, new HashMap<>())) {
 				TrackedValue<?> value = TrackedValue.create(defaultValue, field.getName(), valueBuilder -> {
 					field.setAccessible(true);
 

--- a/src/main/java/org/quiltmc/config/impl/util/ConfigUtils.java
+++ b/src/main/java/org/quiltmc/config/impl/util/ConfigUtils.java
@@ -15,9 +15,12 @@
  */
 package org.quiltmc.config.impl.util;
 
+import org.quiltmc.config.api.ConfigTypeWrapper;
 import org.quiltmc.config.api.exceptions.TrackedValueException;
 import org.quiltmc.config.api.values.CompoundConfigValue;
 import org.quiltmc.config.api.values.ConfigSerializableObject;
+
+import java.util.Map;
 
 public final class ConfigUtils {
 	private static final Class<?>[] VALID_VALUE_CLASSES = new Class[] {
@@ -34,15 +37,15 @@ public final class ConfigUtils {
 			String.class
 	};
 
-	public static void assertValueType(Object object) {
+	public static void assertValueType(Object object, Map<Class<?>, ConfigTypeWrapper<?, ?>> typeWrapper) {
 		if (object == null) {
 			throw new TrackedValueException("Cannot create value with null default value");
-		} else if (!isValidValue(object)) {
+		} else if (!isValidValue(object, typeWrapper)) {
 			throw new TrackedValueException("Cannot create value of type '" + object.getClass() + "'");
 		}
 	}
 
-	public static boolean isValidValue(Object object) {
+	public static boolean isValidValue(Object object, Map<Class<?>, ConfigTypeWrapper<?, ?>> typeWrapper) {
 		if (object == null) {
 			return false;
 		} else if (object instanceof ConfigSerializableObject) {
@@ -52,7 +55,10 @@ public final class ConfigUtils {
 				object = ((CompoundConfigValue<?>) object).getDefaultValue();
 			}
 
-			return isValidValue(object);
+			return isValidValue(object, typeWrapper);
+		} else if (typeWrapper.containsKey(object.getClass())) {
+			ConfigTypeWrapper configTypeWrapper = typeWrapper.get(object.getClass());
+			return isValidValue(configTypeWrapper.getRepresentation(object), typeWrapper);
 		} else {
 			return isValidValueClass(object.getClass());
 		}

--- a/src/test/java/org/quiltmc/config/ConfigTester.java
+++ b/src/test/java/org/quiltmc/config/ConfigTester.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.quiltmc.config.api.Config;
 import org.quiltmc.config.api.ConfigEnvironment;
+import org.quiltmc.config.api.ConfigTypeWrapper;
 import org.quiltmc.config.api.Constraint;
 import org.quiltmc.config.api.annotations.Comment;
 import org.quiltmc.config.api.exceptions.ConfigFieldException;
@@ -48,6 +49,7 @@ public class ConfigTester {
 	static TrackedValue<Boolean> TEST_BOOLEAN;
 	static TrackedValue<String> TEST_STRING;
 	static TrackedValue<ValueList<Integer>> TEST_LIST;
+    static TrackedValue<DoubleWrappedValue> TEST_DOUBLE_WRAPPED;
 
 	@BeforeAll
 	public static void initializeConfigDir() {
@@ -330,4 +332,52 @@ public class ConfigTester {
 			}
 		}
 	}
+
+	@Test
+	public void testWrappedValue() {
+
+		Config config = Config.create(ENV, "testmod", "testConfigWrapped", builder -> {
+			builder.addTypeWrapper(WrappedValue.class, new ConfigTypeWrapper<String, WrappedValue>() {
+				@Override
+				public WrappedValue convertFrom(String representation) {
+					return new WrappedValue(representation);
+				}
+
+				@Override
+				public String getRepresentation(WrappedValue value) {
+					return value.value;
+				}
+			});
+			builder.field(TrackedValue.create(new WrappedValue("aString"), "testString"));
+		});
+	}
+
+	@Test
+	public void testDoubleWrappedValue() {
+		Config config = Config.create(ENV, "testmod", "testConfigDoubleWrapped", builder -> {
+			builder.addTypeWrapper(WrappedValue.class, new ConfigTypeWrapper<String, WrappedValue>() {
+				@Override
+				public WrappedValue convertFrom(String representation) {
+					return new WrappedValue(representation);
+				}
+
+				@Override
+				public String getRepresentation(WrappedValue value) {
+					return value.value;
+				}
+			});
+			builder.addTypeWrapper(DoubleWrappedValue.class, new ConfigTypeWrapper<WrappedValue, DoubleWrappedValue>() {
+				@Override
+				public DoubleWrappedValue convertFrom(WrappedValue representation) {
+					return new DoubleWrappedValue(representation);
+				}
+
+				@Override
+				public WrappedValue getRepresentation(DoubleWrappedValue value) {
+					return value.value;
+				}
+			});
+			builder.field(TEST_DOUBLE_WRAPPED = TrackedValue.create(new DoubleWrappedValue(new WrappedValue("aString")), "testString"));
+		});
+    }
 }

--- a/src/test/java/org/quiltmc/config/DoubleWrappedValue.java
+++ b/src/test/java/org/quiltmc/config/DoubleWrappedValue.java
@@ -1,0 +1,9 @@
+package org.quiltmc.config;
+
+public class DoubleWrappedValue {
+    public final WrappedValue value;
+
+    public DoubleWrappedValue(WrappedValue value) {
+        this.value = value;
+    }
+}

--- a/src/test/java/org/quiltmc/config/WrappedValue.java
+++ b/src/test/java/org/quiltmc/config/WrappedValue.java
@@ -1,0 +1,9 @@
+package org.quiltmc.config;
+
+public class WrappedValue {
+    public final String value;
+
+    public WrappedValue(String value) {
+        this.value = value;
+    }
+}


### PR DESCRIPTION
Add basic type Wrapper Implementation.

This change allows users to define type wrapper for objects out of their control. An example usage would be to create a ConfigTypeWrapper for Identifier, so mod creators can easily use this to have config values for things in a registry.

This also supports recursive lookups so someone can add their wrapper from Identifier to EntityType and use a provided String to Identifier wrapper.

Limitations that are going to be adressed if this is an acceptable implementation:

- Reflective Configs don't support ConfigTypeWrappers
- ConfigSections don't support ConfigTypeWrappers, because they don't have access to the ConfigTypeWrapper in the ConfigImpl
- NightConfigSerializer doesn't support Child Classes, because it doesn't use the default value in it's  serialization