### PR TITLE
`1.1.0`: bump version, bump dependencies, fix a typo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 group 'org.quiltmc'
-version '1.1.0-beta.3'
+version '1.1.0'
 
 java {
 	withSourcesJar()
@@ -23,11 +23,11 @@ repositories {
 }
 
 dependencies {
-	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
-	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
-	testImplementation 'com.electronwill.night-config:core:3.6.5'
-	testImplementation 'com.electronwill.night-config:toml:3.6.5'
-	testImplementation 'org.quiltmc:quilt-json5:1.0.0'
+	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.0'
+	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
+	testImplementation 'com.electronwill.night-config:core:3.6.6'
+	testImplementation 'com.electronwill.night-config:toml:3.6.6'
+	testImplementation 'org.quiltmc:quilt-json5:1.0.4+final'
 
 	implementation 'org.jetbrains:annotations:23.0.0'
 }

--- a/src/main/java/org/quiltmc/config/api/values/TrackedValue.java
+++ b/src/main/java/org/quiltmc/config/api/values/TrackedValue.java
@@ -58,7 +58,7 @@ public interface TrackedValue<T> extends ValueTreeNode {
 
 	/**
 	 * @param newValue the value to set
-	 * @param serialize whether or not to serialize this values config file. Should be false only when deserializing
+	 * @param serialize whether or not to serialize this value's backing config file. Should be false only when deserializing
 	 * @return the old value that's been replaced
 	 */
 	T setValue(@NotNull T newValue, boolean serialize);


### PR DESCRIPTION
glitch said on discord that the only reason `1.1` wasn't out was because the button wasn't pushed. this pr does some general updating and bumps it!