### PR TITLE
implement `@SerializedName` annotation, make default serializers public

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 group 'org.quiltmc'
-version '1.2.0'
+version '1.2.0-beta.1'
 
 java {
 	withSourcesJar()

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
 	implementation 'com.electronwill.night-config:core:3.6.6'
 	implementation 'com.electronwill.night-config:toml:3.6.6'
-	testImplementation 'org.quiltmc:quilt-json5:1.0.4+final'
+	implementation 'org.quiltmc.parsers:json:0.2.1'
 
 	implementation 'org.jetbrains:annotations:23.0.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ plugins {
 	id 'org.quiltmc.gradle.licenser' version '1.+'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_16
+targetCompatibility = JavaVersion.VERSION_16
 
 group 'org.quiltmc'
 version '1.1.0'
@@ -25,8 +25,8 @@ repositories {
 dependencies {
 	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.0'
 	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
-	testImplementation 'com.electronwill.night-config:core:3.6.6'
-	testImplementation 'com.electronwill.night-config:toml:3.6.6'
+	implementation 'com.electronwill.night-config:core:3.6.6'
+	implementation 'com.electronwill.night-config:toml:3.6.6'
 	testImplementation 'org.quiltmc:quilt-json5:1.0.4+final'
 
 	implementation 'org.jetbrains:annotations:23.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ plugins {
 	id 'org.quiltmc.gradle.licenser' version '1.+'
 }
 
-sourceCompatibility = JavaVersion.VERSION_16
-targetCompatibility = JavaVersion.VERSION_16
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 group 'org.quiltmc'
 version '1.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 group 'org.quiltmc'
-version '1.1.0'
+version '1.2.0'
 
 java {
 	withSourcesJar()

--- a/src/main/java/org/quiltmc/config/api/annotations/Matches.java
+++ b/src/main/java/org/quiltmc/config/api/annotations/Matches.java
@@ -16,11 +16,6 @@
 
 package org.quiltmc.config.api.annotations;
 
-import org.quiltmc.config.api.Constraint;
-import org.quiltmc.config.api.metadata.MetadataContainerBuilder;
-import org.quiltmc.config.api.values.TrackedValue;
-import org.quiltmc.config.api.values.CompoundConfigValue;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/src/main/java/org/quiltmc/config/api/annotations/SerializedName.java
+++ b/src/main/java/org/quiltmc/config/api/annotations/SerializedName.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022-2023 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.config.api.annotations;
+
+import org.quiltmc.config.api.Config;
+import org.quiltmc.config.api.metadata.MetadataType;
+import org.quiltmc.config.api.metadata.SerialName;
+
+import java.lang.annotation.*;
+import java.util.*;
+
+/**
+ * Used to tell the serializer what name should be used for this field when saving to disk
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface SerializedName {
+	/**
+	 * A {@link MetadataType} to supply to {@link Config.Builder#metadata}
+	 */
+	MetadataType<SerialName, Builder> TYPE = MetadataType.create(Optional::empty, Builder::new);
+
+	String value();
+
+	final class Builder implements MetadataType.Builder<SerialName> {
+		private String name;
+
+		public Builder() {
+		}
+
+		public void withName(String name) {
+			this.name = name;
+		}
+
+		@Override
+		public SerialName build() {
+			return new SerialName(this.name);
+		}
+	}
+}
+

--- a/src/main/java/org/quiltmc/config/api/metadata/SerialName.java
+++ b/src/main/java/org/quiltmc/config/api/metadata/SerialName.java
@@ -1,0 +1,13 @@
+package org.quiltmc.config.api.metadata;
+
+public class SerialName {
+	private final String name;
+
+	public SerialName(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+}

--- a/src/main/java/org/quiltmc/config/api/metadata/SerialName.java
+++ b/src/main/java/org/quiltmc/config/api/metadata/SerialName.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.config.api.metadata;
 
 public class SerialName {

--- a/src/main/java/org/quiltmc/config/api/metadata/SerialName.java
+++ b/src/main/java/org/quiltmc/config/api/metadata/SerialName.java
@@ -16,10 +16,16 @@
 
 package org.quiltmc.config.api.metadata;
 
+import java.security.InvalidParameterException;
+
 public class SerialName {
 	private final String name;
 
 	public SerialName(String name) {
+		if (name == null || name.equals("")) {
+			throw new InvalidParameterException("Cannot set serialized name to an empty value!");
+		}
+
 		this.name = name;
 	}
 

--- a/src/main/java/org/quiltmc/config/api/serializer/Json5Serializer.java
+++ b/src/main/java/org/quiltmc/config/api/serializer/Json5Serializer.java
@@ -14,23 +14,39 @@
  * limitations under the License.
  */
 
-package org.quiltmc.config;
+package org.quiltmc.config.api.serializer;
 
-import org.quiltmc.json5.JsonReader;
-import org.quiltmc.json5.JsonToken;
-import org.quiltmc.json5.JsonWriter;
-import org.quiltmc.config.api.*;
+import org.quiltmc.config.api.Config;
+import org.quiltmc.config.api.Constraint;
+import org.quiltmc.config.api.MarshallingUtils;
+import org.quiltmc.config.api.Serializer;
 import org.quiltmc.config.api.annotations.Comment;
+import org.quiltmc.config.api.annotations.SerializedName;
 import org.quiltmc.config.api.exceptions.ConfigParseException;
-import org.quiltmc.config.api.values.*;
+import org.quiltmc.config.api.values.CompoundConfigValue;
+import org.quiltmc.config.api.values.ConfigSerializableObject;
+import org.quiltmc.config.api.values.TrackedValue;
+import org.quiltmc.config.api.values.ValueList;
+import org.quiltmc.config.api.values.ValueMap;
+import org.quiltmc.config.api.values.ValueTreeNode;
 import org.quiltmc.config.impl.tree.TrackedValueImpl;
+import org.quiltmc.parsers.json.JsonReader;
+import org.quiltmc.parsers.json.JsonToken;
+import org.quiltmc.parsers.json.JsonWriter;
 
-import java.io.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * A default serializer that writes in the <a href="https://json5.org/">JSON5 format</a>.
+ */
 public final class Json5Serializer implements Serializer {
 	public static final Json5Serializer INSTANCE = new Json5Serializer();
 
@@ -127,7 +143,12 @@ public final class Json5Serializer implements Serializer {
 				writer.comment("default: " + defaultValue);
 			}
 
-			writer.name(node.key().getLastComponent());
+			String name = trackedValue.key().toString();
+			if (trackedValue.hasMetadata(SerializedName.TYPE)) {
+				name = trackedValue.metadata(SerializedName.TYPE).getName();
+			}
+
+			writer.name(name);
 
 			serialize(writer, trackedValue.getRealValue());
 		}
@@ -163,12 +184,15 @@ public final class Json5Serializer implements Serializer {
 				Map<String, Object> m = values;
 
 				for (int i = 0; i < value.key().length(); ++i) {
-					String k = value.key().getKeyComponent(i);
+					String name = value.key().getKeyComponent(i);
+					if (value.hasMetadata(SerializedName.TYPE)) {
+						name = value.metadata(SerializedName.TYPE).getName();
+					}
 
-					if (m.containsKey(k) && i != value.key().length() - 1) {
-						m = (Map<String, Object>) m.get(k);
-					} else if (m.containsKey(k)) {
-						((TrackedValueImpl) value).setValue(MarshallingUtils.coerce(m.get(k), value.getDefaultValue(), (Map<String, ?> map, MarshallingUtils.MapEntryConsumer entryConsumer) ->
+					if (m.containsKey(name) && i != value.key().length() - 1) {
+						m = (Map<String, Object>) m.get(name);
+					} else if (m.containsKey(name)) {
+						((TrackedValueImpl) value).setValue(MarshallingUtils.coerce(m.get(name), value.getDefaultValue(), (Map<String, ?> map, MarshallingUtils.MapEntryConsumer entryConsumer) ->
 								map.forEach(entryConsumer::put)), false);
 					}
 				}

--- a/src/main/java/org/quiltmc/config/api/serializer/TomlSerializer.java
+++ b/src/main/java/org/quiltmc/config/api/serializer/TomlSerializer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.config.api.serializer;
 
 import com.electronwill.nightconfig.core.CommentedConfig;
@@ -27,10 +43,17 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * A default serializer that writes in the <a href="https://toml.io/en/">TOML format</a>.
+ */
 public final class TomlSerializer implements Serializer {
 	public static final TomlSerializer INSTANCE = new TomlSerializer();
 	private final ConfigParser<CommentedConfig> parser = new TomlParser();
 	private final ConfigWriter writer = new TomlWriter();
+
+	private TomlSerializer() {
+
+	}
 
 	@Override
 	public String getFileExtension() {

--- a/src/main/java/org/quiltmc/config/api/serializer/TomlSerializer.java
+++ b/src/main/java/org/quiltmc/config/api/serializer/TomlSerializer.java
@@ -102,8 +102,9 @@ public final class TomlSerializer implements Serializer {
 				}
 			}
 
-			if (node instanceof TrackedValue<?> trackedValue) {
-				Object defaultValue = trackedValue.getDefaultValue();
+			if (node instanceof TrackedValue<?>) {
+				TrackedValue<?> value = (TrackedValue<?>) node;
+				Object defaultValue = value.getDefaultValue();
 
 				if (defaultValue.getClass().isEnum()) {
 					StringBuilder options = new StringBuilder("options: ");
@@ -122,7 +123,7 @@ public final class TomlSerializer implements Serializer {
 					comments.add(options.toString());
 				}
 
-				for (Constraint<?> constraint : trackedValue.constraints()) {
+				for (Constraint<?> constraint : value.constraints()) {
 					comments.add(constraint.getRepresentation());
 				}
 
@@ -130,12 +131,12 @@ public final class TomlSerializer implements Serializer {
 					comments.add("default: " + defaultValue);
 				}
 
-				String name = trackedValue.key().toString();
-				if (trackedValue.hasMetadata(SerializedName.TYPE)) {
-					name = trackedValue.metadata(SerializedName.TYPE).getName();
+				String name = value.key().toString();
+				if (value.hasMetadata(SerializedName.TYPE)) {
+					name = value.metadata(SerializedName.TYPE).getName();
 				}
 
-				config.add(name, convertAny(trackedValue.getRealValue()));
+				config.add(name, convertAny(value.getRealValue()));
 			} else {
 				write(config, ((ValueTreeNode.Section) node));
 			}

--- a/src/main/java/org/quiltmc/config/impl/ConfigFieldAnnotationProcessors.java
+++ b/src/main/java/org/quiltmc/config/impl/ConfigFieldAnnotationProcessors.java
@@ -35,6 +35,7 @@ public final class ConfigFieldAnnotationProcessors {
 		register(IntegerRange.class, new IntegerRangeProcessor());
 		register(FloatRange.class, new FloatRangeProcessor());
 		register(Matches.class, new MatchesProcessor());
+		register(SerializedName.class, new SerialNameProcessor());
 	}
 
 	public static <T extends Annotation> void register(Class<T> annotationClass, ConfigFieldAnnotationProcessor<T> processor) {
@@ -59,6 +60,13 @@ public final class ConfigFieldAnnotationProcessors {
 			for (String c : comment.value()) {
 				builder.metadata(Comment.TYPE, comments -> comments.add(c));
 			}
+		}
+	}
+
+	private static final class SerialNameProcessor implements ConfigFieldAnnotationProcessor<SerializedName> {
+		@Override
+		public void process(SerializedName name, MetadataContainerBuilder<?> builder) {
+			builder.metadata(SerializedName.TYPE, nameBuilder -> nameBuilder.withName(name.value()));
 		}
 	}
 

--- a/src/main/java/org/quiltmc/config/impl/util/SerializerUtils.java
+++ b/src/main/java/org/quiltmc/config/impl/util/SerializerUtils.java
@@ -1,0 +1,41 @@
+package org.quiltmc.config.impl.util;
+
+import org.quiltmc.config.api.annotations.SerializedName;
+import org.quiltmc.config.api.values.TrackedValue;
+
+import java.util.Optional;
+
+public class SerializerUtils {
+	public static Optional<String> createEnumOptionsComment(Object defaultValue) {
+		if (defaultValue.getClass().isEnum()) {
+			StringBuilder options = new StringBuilder("options: ");
+			Object[] enumConstants = defaultValue.getClass().getEnumConstants();
+
+			for (int i = 0, enumConstantsLength = enumConstants.length; i < enumConstantsLength; i++) {
+				Object o = enumConstants[i];
+
+				options.append(o);
+
+				if (i < enumConstantsLength - 1) {
+					options.append(", ");
+				}
+			}
+
+			return Optional.of(options.toString());
+		} else {
+			return Optional.empty();
+		}
+	}
+
+	/**
+	 * Gets the value's name, taking {@link SerializedName} into account. Should always be used when serializing and deserializing a config.
+	 */
+	public static String getName(TrackedValue<?> value) {
+		String name = value.key().toString();
+		if (value.hasMetadata(SerializedName.TYPE)) {
+			name = value.metadata(SerializedName.TYPE).getName();
+		}
+
+		return name;
+	}
+}

--- a/src/main/java/org/quiltmc/config/impl/util/SerializerUtils.java
+++ b/src/main/java/org/quiltmc/config/impl/util/SerializerUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.config.impl.util;
 
 import org.quiltmc.config.api.annotations.SerializedName;

--- a/src/test/java/org/quiltmc/config/ConfigTester.java
+++ b/src/test/java/org/quiltmc/config/ConfigTester.java
@@ -16,8 +16,6 @@
 
 package org.quiltmc.config;
 
-import com.electronwill.nightconfig.toml.TomlParser;
-import com.electronwill.nightconfig.toml.TomlWriter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -29,11 +27,17 @@ import org.quiltmc.config.api.exceptions.ConfigFieldException;
 import org.quiltmc.config.api.exceptions.TrackedValueException;
 import org.quiltmc.config.api.metadata.Comments;
 import org.quiltmc.config.api.metadata.MetadataType;
+import org.quiltmc.config.api.serializer.TomlSerializer;
 import org.quiltmc.config.api.values.TrackedValue;
 import org.quiltmc.config.api.values.ValueList;
 import org.quiltmc.config.api.values.ValueMap;
 import org.quiltmc.config.impl.CommentsImpl;
-import org.quiltmc.config.oldwrapped.*;
+import org.quiltmc.config.oldwrapped.TestValueConfig3;
+import org.quiltmc.config.oldwrapped.TestValueConfig4;
+import org.quiltmc.config.oldwrapped.TestValueListConfig;
+import org.quiltmc.config.oldwrapped.TestValueMapConfig;
+import org.quiltmc.config.oldwrapped.TestWrappedConfig;
+import org.quiltmc.config.oldwrapped.TestWrappedConfig2;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -54,7 +58,7 @@ public class ConfigTester {
 
 	@BeforeAll
 	public static void initializeConfigDir() {
-		ENV = new ConfigEnvironment(TEMP, new NightConfigSerializer<>("toml", new TomlParser(), new TomlWriter()), Json5Serializer.INSTANCE);
+		ENV = new ConfigEnvironment(TEMP, TomlSerializer.INSTANCE, Json5Serializer.INSTANCE);
 	}
 
 	@Test

--- a/src/test/java/org/quiltmc/config/ConfigTester.java
+++ b/src/test/java/org/quiltmc/config/ConfigTester.java
@@ -27,6 +27,7 @@ import org.quiltmc.config.api.exceptions.ConfigFieldException;
 import org.quiltmc.config.api.exceptions.TrackedValueException;
 import org.quiltmc.config.api.metadata.Comments;
 import org.quiltmc.config.api.metadata.MetadataType;
+import org.quiltmc.config.api.serializer.Json5Serializer;
 import org.quiltmc.config.api.serializer.TomlSerializer;
 import org.quiltmc.config.api.values.TrackedValue;
 import org.quiltmc.config.api.values.ValueList;


### PR DESCRIPTION
other changes of note:
- migrated to QUP for json5 serialization

fixes #13 
fixes #12 

these are the two design things that keep me from absolutely loving qconf right now. if there's a reason these changes shouldn't be made let's argue!