### PR TITLE
read write cycle testing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 group 'org.quiltmc'
-version '1.2.0-beta.3'
+version '1.2.0-beta.4'
 
 java {
 	withSourcesJar()

--- a/src/main/java/org/quiltmc/config/api/Config.java
+++ b/src/main/java/org/quiltmc/config/api/Config.java
@@ -48,7 +48,7 @@ public interface Config extends MetadataContainer {
 	Path savePath();
 
 	/**
-	 * Adds a listener to this {@link Config} that's called whenever any of its values are updated
+	 * Adds a listener to this {@link Config} that's called whenever any of its values are updated.
 	 *
 	 * @param callback an update listener
 	 */
@@ -60,17 +60,17 @@ public interface Config extends MetadataContainer {
 	<M> M metadata(MetadataType<M, ?> type);
 
 	/**
-	 * @return whether or not this value has any metadata of the specified type
+	 * @return whether this value has any metadata of the specified type
 	 */
 	<M> boolean hasMetadata(MetadataType<M, ?> type);
 
 	/**
-	 * Serialize this config and all its values to disk
+	 * Serialize this config and all its values to disk.
 	 */
 	void save();
 
 	/**
-	 * Returns all values held by this config file
+	 * Returns all values held by this config file.
 	 *
 	 * <p>For all nodes, including section nodes, see {@link #nodes}
 	 *
@@ -81,11 +81,12 @@ public interface Config extends MetadataContainer {
 	/**
 	 * @param key an iterable of key components that make up a {@link TrackedValue}'s {@link ValueKey}
 	 * @return the value contained by this config class
+	 * @apiNote this method assumes that the key points to a value and not a section
 	 */
 	TrackedValue<?> getValue(Iterable<String> key);
 
 	/**
-	 * Returns all top-level nodes of the value tree represented by this config file, including section nodes
+	 * Returns all top-level nodes of the value tree represented by this config file, including section nodes.
 	 *
 	 * <p>Consider a config represented by the following JSON5 file:
 	 * <pre>
@@ -111,6 +112,10 @@ public interface Config extends MetadataContainer {
 	 */
 	Iterable<ValueTreeNode> nodes();
 
+	/**
+	 * @param key an iterable of key components that make up a {@link TrackedValue}'s {@link ValueKey}
+	 * @return the node contained by this config class, which can either be a value node or a section node
+	 */
 	ValueTreeNode getNode(Iterable<String> key);
 
 	/**

--- a/src/main/java/org/quiltmc/config/api/Config.java
+++ b/src/main/java/org/quiltmc/config/api/Config.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/ConfigEnvironment.java
+++ b/src/main/java/org/quiltmc/config/api/ConfigEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 QuiltMC
+ * Copyright 2023-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/Configs.java
+++ b/src/main/java/org/quiltmc/config/api/Configs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/Constraint.java
+++ b/src/main/java/org/quiltmc/config/api/Constraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/InternalsHelper.java
+++ b/src/main/java/org/quiltmc/config/api/InternalsHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 QuiltMC
+ * Copyright 2023-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/MarshallingUtils.java
+++ b/src/main/java/org/quiltmc/config/api/MarshallingUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/ReflectiveConfig.java
+++ b/src/main/java/org/quiltmc/config/api/ReflectiveConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 QuiltMC
+ * Copyright 2023-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/ReflectiveConfig.java
+++ b/src/main/java/org/quiltmc/config/api/ReflectiveConfig.java
@@ -28,6 +28,7 @@ import org.quiltmc.config.impl.util.ConfigUtils;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.Map;
 
 public abstract class ReflectiveConfig implements Config {
 	private Config wrapped;
@@ -60,6 +61,11 @@ public abstract class ReflectiveConfig implements Config {
 	@Override
 	public final <M> boolean hasMetadata(MetadataType<M, ?> type) {
 		return this.wrapped.hasMetadata(type);
+	}
+
+	@Override
+	public Map<MetadataType<?, ?>, Object> metadata() {
+		return this.wrapped.metadata();
 	}
 
 	@Override

--- a/src/main/java/org/quiltmc/config/api/Serializer.java
+++ b/src/main/java/org/quiltmc/config/api/Serializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/WrappedConfig.java
+++ b/src/main/java/org/quiltmc/config/api/WrappedConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/annotations/Comment.java
+++ b/src/main/java/org/quiltmc/config/api/annotations/Comment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/annotations/ConfigFieldAnnotationProcessor.java
+++ b/src/main/java/org/quiltmc/config/api/annotations/ConfigFieldAnnotationProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/annotations/ConfigFieldAnnotationProcessors.java
+++ b/src/main/java/org/quiltmc/config/api/annotations/ConfigFieldAnnotationProcessors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/annotations/FloatRange.java
+++ b/src/main/java/org/quiltmc/config/api/annotations/FloatRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/annotations/IntegerRange.java
+++ b/src/main/java/org/quiltmc/config/api/annotations/IntegerRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/annotations/Matches.java
+++ b/src/main/java/org/quiltmc/config/api/annotations/Matches.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/annotations/Processor.java
+++ b/src/main/java/org/quiltmc/config/api/annotations/Processor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/annotations/SerializedName.java
+++ b/src/main/java/org/quiltmc/config/api/annotations/SerializedName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/exceptions/ConfigCreationException.java
+++ b/src/main/java/org/quiltmc/config/api/exceptions/ConfigCreationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/exceptions/ConfigFieldException.java
+++ b/src/main/java/org/quiltmc/config/api/exceptions/ConfigFieldException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/exceptions/ConfigParseException.java
+++ b/src/main/java/org/quiltmc/config/api/exceptions/ConfigParseException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/exceptions/TrackedValueException.java
+++ b/src/main/java/org/quiltmc/config/api/exceptions/TrackedValueException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/metadata/Comments.java
+++ b/src/main/java/org/quiltmc/config/api/metadata/Comments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/metadata/MetadataContainer.java
+++ b/src/main/java/org/quiltmc/config/api/metadata/MetadataContainer.java
@@ -16,6 +16,8 @@
 
 package org.quiltmc.config.api.metadata;
 
+import java.util.Map;
+
 public interface MetadataContainer {
 	/**
 	 * @return the metadata attached to this value for the specified type
@@ -23,7 +25,12 @@ public interface MetadataContainer {
 	<M> M metadata(MetadataType<M, ?> type);
 
 	/**
-	 * @return whether or not this value has any metadata of the specified type
+	 * @return whether this value has any metadata of the specified type
 	 */
 	<M> boolean hasMetadata(MetadataType<M, ?> type);
+
+	/**
+	 * @return a map of all metadata attached to this node
+	 */
+	Map<MetadataType<?, ?>, Object> metadata();
 }

--- a/src/main/java/org/quiltmc/config/api/metadata/MetadataContainer.java
+++ b/src/main/java/org/quiltmc/config/api/metadata/MetadataContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/metadata/MetadataContainerBuilder.java
+++ b/src/main/java/org/quiltmc/config/api/metadata/MetadataContainerBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/metadata/MetadataType.java
+++ b/src/main/java/org/quiltmc/config/api/metadata/MetadataType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/metadata/SerialName.java
+++ b/src/main/java/org/quiltmc/config/api/metadata/SerialName.java
@@ -17,12 +17,13 @@
 package org.quiltmc.config.api.metadata;
 
 import java.security.InvalidParameterException;
+import java.util.Objects;
 
 public class SerialName {
 	private final String name;
 
 	public SerialName(String name) {
-		if (name == null || name.equals("")) {
+		if (name == null || name.isEmpty()) {
 			throw new InvalidParameterException("Cannot set serialized name to an empty value!");
 		}
 
@@ -31,5 +32,18 @@ public class SerialName {
 
 	public String getName() {
 		return name;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		SerialName that = (SerialName) o;
+		return Objects.equals(name, that.name);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(name);
 	}
 }

--- a/src/main/java/org/quiltmc/config/api/metadata/SerialName.java
+++ b/src/main/java/org/quiltmc/config/api/metadata/SerialName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 QuiltMC
+ * Copyright 2023-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/serializer/Json5Serializer.java
+++ b/src/main/java/org/quiltmc/config/api/serializer/Json5Serializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/serializer/TomlSerializer.java
+++ b/src/main/java/org/quiltmc/config/api/serializer/TomlSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 QuiltMC
+ * Copyright 2023-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/values/ComplexConfigValue.java
+++ b/src/main/java/org/quiltmc/config/api/values/ComplexConfigValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/values/CompoundConfigValue.java
+++ b/src/main/java/org/quiltmc/config/api/values/CompoundConfigValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/values/ConfigSerializableObject.java
+++ b/src/main/java/org/quiltmc/config/api/values/ConfigSerializableObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/values/TrackedValue.java
+++ b/src/main/java/org/quiltmc/config/api/values/TrackedValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/values/ValueKey.java
+++ b/src/main/java/org/quiltmc/config/api/values/ValueKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/values/ValueList.java
+++ b/src/main/java/org/quiltmc/config/api/values/ValueList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/values/ValueMap.java
+++ b/src/main/java/org/quiltmc/config/api/values/ValueMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/api/values/ValueTreeNode.java
+++ b/src/main/java/org/quiltmc/config/api/values/ValueTreeNode.java
@@ -18,25 +18,17 @@ package org.quiltmc.config.api.values;
 
 import org.jetbrains.annotations.ApiStatus;
 import org.quiltmc.config.api.metadata.MetadataContainer;
-import org.quiltmc.config.api.metadata.MetadataType;
 
 /**
- * An element in a configs value tree.
+ * An element in a config's value tree.
  *
  * <p>Will be either a {@link TrackedValue} or {@link Section}
  */
 public interface ValueTreeNode extends MetadataContainer {
+	/**
+	 * @return this value's key
+	 */
 	ValueKey key();
-
-	/**
-	 * @return the metadata attached to this value for the specified type
-	 */
-	<M> M metadata(MetadataType<M, ?> type);
-
-	/**
-	 * @return whether or not this value has any metadata of the specified type
-	 */
-	<M> boolean hasMetadata(MetadataType<M, ?> type);
 
 	/**
 	 * A node that contains any number of child nodes.

--- a/src/main/java/org/quiltmc/config/api/values/ValueTreeNode.java
+++ b/src/main/java/org/quiltmc/config/api/values/ValueTreeNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/impl/AbstractMetadataContainer.java
+++ b/src/main/java/org/quiltmc/config/impl/AbstractMetadataContainer.java
@@ -48,4 +48,8 @@ public abstract class AbstractMetadataContainer implements MetadataContainer {
 	public <M> boolean hasMetadata(MetadataType<M, ?> type) {
 		return this.metadata.containsKey(type) || type.getDefaultValue(this).isPresent();
 	}
+
+	public Map<MetadataType<?, ?>, Object> metadata() {
+		return this.metadata;
+	}
 }

--- a/src/main/java/org/quiltmc/config/impl/AbstractMetadataContainer.java
+++ b/src/main/java/org/quiltmc/config/impl/AbstractMetadataContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/impl/Comments.java
+++ b/src/main/java/org/quiltmc/config/impl/Comments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/impl/CommentsImpl.java
+++ b/src/main/java/org/quiltmc/config/impl/CommentsImpl.java
@@ -23,6 +23,7 @@ import org.quiltmc.config.impl.util.ImmutableIterable;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 public final class CommentsImpl implements Comments {
 	private final List<String> comments;
@@ -35,5 +36,18 @@ public final class CommentsImpl implements Comments {
 	@Override
 	public Iterator<String> iterator() {
 		return new ImmutableIterable<>(this.comments).iterator();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		CommentsImpl strings = (CommentsImpl) o;
+		return Objects.equals(comments, strings.comments);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(comments);
 	}
 }

--- a/src/main/java/org/quiltmc/config/impl/CommentsImpl.java
+++ b/src/main/java/org/quiltmc/config/impl/CommentsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/impl/ConfigFieldAnnotationProcessors.java
+++ b/src/main/java/org/quiltmc/config/impl/ConfigFieldAnnotationProcessors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/impl/ConfigImpl.java
+++ b/src/main/java/org/quiltmc/config/impl/ConfigImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/impl/builders/ConfigBuilderImpl.java
+++ b/src/main/java/org/quiltmc/config/impl/builders/ConfigBuilderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/impl/builders/ReflectiveConfigCreator.java
+++ b/src/main/java/org/quiltmc/config/impl/builders/ReflectiveConfigCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 QuiltMC
+ * Copyright 2023-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/impl/builders/SectionBuilderImpl.java
+++ b/src/main/java/org/quiltmc/config/impl/builders/SectionBuilderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/impl/builders/TrackedValueBuilderImpl.java
+++ b/src/main/java/org/quiltmc/config/impl/builders/TrackedValueBuilderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/impl/builders/ValueMapBuilderImpl.java
+++ b/src/main/java/org/quiltmc/config/impl/builders/ValueMapBuilderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/impl/builders/WrappedConfigCreator.java
+++ b/src/main/java/org/quiltmc/config/impl/builders/WrappedConfigCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/impl/tree/SectionTreeNode.java
+++ b/src/main/java/org/quiltmc/config/impl/tree/SectionTreeNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/impl/tree/TrackedValueImpl.java
+++ b/src/main/java/org/quiltmc/config/impl/tree/TrackedValueImpl.java
@@ -146,7 +146,6 @@ public final class TrackedValueImpl<T> extends AbstractMetadataContainer impleme
 	@Override
 	public void removeOverride() {
 		this.isBeingOverridden = false;
-		T oldValueOverride = this.valueOverride;
 		this.valueOverride = null;
 
 		this.invokeCallbacks();
@@ -214,5 +213,10 @@ public final class TrackedValueImpl<T> extends AbstractMetadataContainer impleme
 		for (UpdateCallback<T> callback : this.callbacks) {
 			callback.onUpdate(this);
 		}
+	}
+
+	@Override
+	public String toString() {
+		return String.format("TrackedValueImpl[%s]", this.value.toString());
 	}
 }

--- a/src/main/java/org/quiltmc/config/impl/tree/TrackedValueImpl.java
+++ b/src/main/java/org/quiltmc/config/impl/tree/TrackedValueImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/impl/tree/Trie.java
+++ b/src/main/java/org/quiltmc/config/impl/tree/Trie.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/impl/util/ConfigUtils.java
+++ b/src/main/java/org/quiltmc/config/impl/util/ConfigUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/impl/util/ConfigsImpl.java
+++ b/src/main/java/org/quiltmc/config/impl/util/ConfigsImpl.java
@@ -18,6 +18,7 @@ package org.quiltmc.config.impl.util;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.TestOnly;
 import org.quiltmc.config.api.Config;
 import org.quiltmc.config.api.exceptions.ConfigCreationException;
 
@@ -39,9 +40,7 @@ public final class ConfigsImpl {
 		CONFIGS.computeIfAbsent(familyId, id -> new TreeMap<>()).put(config.id(), config);
 	}
 
-	/**
-	 * Not intended to be used for anything other than testing.
-	 */
+	@TestOnly
 	public static void remove(Config config) {
 		CONFIGS.get(config.family()).remove(config.id());
 	}

--- a/src/main/java/org/quiltmc/config/impl/util/ConfigsImpl.java
+++ b/src/main/java/org/quiltmc/config/impl/util/ConfigsImpl.java
@@ -20,7 +20,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.quiltmc.config.api.Config;
 import org.quiltmc.config.api.exceptions.ConfigCreationException;
-import org.quiltmc.config.impl.util.ImmutableIterable;
 
 import java.util.Collections;
 import java.util.Iterator;
@@ -38,6 +37,13 @@ public final class ConfigsImpl {
 		}
 
 		CONFIGS.computeIfAbsent(familyId, id -> new TreeMap<>()).put(config.id(), config);
+	}
+
+	/**
+	 * Not intended to be used for anything other than testing.
+	 */
+	public static void remove(Config config) {
+		CONFIGS.get(config.family()).remove(config.id());
 	}
 
 	public static Iterable<Config> getAll() {

--- a/src/main/java/org/quiltmc/config/impl/util/ConfigsImpl.java
+++ b/src/main/java/org/quiltmc/config/impl/util/ConfigsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/impl/util/ImmutableIterable.java
+++ b/src/main/java/org/quiltmc/config/impl/util/ImmutableIterable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/impl/util/SerializerUtils.java
+++ b/src/main/java/org/quiltmc/config/impl/util/SerializerUtils.java
@@ -51,7 +51,7 @@ public class SerializerUtils {
 	/**
 	 * Gets the value's key, taking {@link SerializedName} into account. Should always be used when serializing and deserializing a config.
 	 */
-	public static String getSerializedKey(Config config, ValueTreeNode value) {
+	public static ValueKey getSerializedKey(Config config, ValueTreeNode value) {
 		List<String> serializedKey = new ArrayList<>();
 		ValueKey key = value.key();
 
@@ -63,7 +63,7 @@ public class SerializerUtils {
 			serializedKey.add(getSerializedName(currentNode));
 		}
 
-		return new ValueKeyImpl(serializedKey.toArray(new String[0])).toString();
+		return new ValueKeyImpl(serializedKey.toArray(new String[0]));
 	}
 
 	public static String getSerializedName(ValueTreeNode value) {

--- a/src/main/java/org/quiltmc/config/impl/util/SerializerUtils.java
+++ b/src/main/java/org/quiltmc/config/impl/util/SerializerUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 QuiltMC
+ * Copyright 2023-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/impl/values/ValueKeyImpl.java
+++ b/src/main/java/org/quiltmc/config/impl/values/ValueKeyImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/impl/values/ValueListImpl.java
+++ b/src/main/java/org/quiltmc/config/impl/values/ValueListImpl.java
@@ -137,7 +137,7 @@ public final class ValueListImpl<T> implements ValueList<T>, CompoundConfigValue
 
 	@Override
 	public boolean containsAll(@NotNull Collection<?> c) {
-		return values.containsAll(c);
+		return new HashSet<>(values).containsAll(c);
 	}
 
 	@Override

--- a/src/main/java/org/quiltmc/config/impl/values/ValueListImpl.java
+++ b/src/main/java/org/quiltmc/config/impl/values/ValueListImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/impl/values/ValueMapImpl.java
+++ b/src/main/java/org/quiltmc/config/impl/values/ValueMapImpl.java
@@ -183,4 +183,17 @@ public final class ValueMapImpl<T> implements ValueMap<T>, CompoundConfigValue<T
 	public Iterator<Entry<String, T>> iterator() {
 		return this.values.entrySet().iterator();
 	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		ValueMapImpl<?> valueMap = (ValueMapImpl<?>) o;
+		return Objects.equals(defaultValue, valueMap.defaultValue) && Objects.equals(values, valueMap.values);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(defaultValue, values, configValue);
+	}
 }

--- a/src/main/java/org/quiltmc/config/impl/values/ValueMapImpl.java
+++ b/src/main/java/org/quiltmc/config/impl/values/ValueMapImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/implementor_api/ConfigEnvironment.java
+++ b/src/main/java/org/quiltmc/config/implementor_api/ConfigEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/implementor_api/ConfigFactory.java
+++ b/src/main/java/org/quiltmc/config/implementor_api/ConfigFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 QuiltMC
+ * Copyright 2023-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/quiltmc/config/implementor_api/package-info.java
+++ b/src/main/java/org/quiltmc/config/implementor_api/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 QuiltMC
+ * Copyright 2023-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/quiltmc/config/ConfigTest.java
+++ b/src/test/java/org/quiltmc/config/ConfigTest.java
@@ -16,6 +16,7 @@
 
 package org.quiltmc.config;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -43,15 +44,13 @@ import org.quiltmc.config.reflective.TestValueMapConfig;
 import org.quiltmc.config.reflective.TestReflectiveConfig;
 import org.quiltmc.config.reflective.TestReflectiveConfig2;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Optional;
 
 @SuppressWarnings("deprecation")
-public class ConfigTester {
-	static Path TEMP = Paths.get("temp");
+public class ConfigTest {
 	static ConfigEnvironment ENV;
 
 	static TrackedValue<String> TEST;
@@ -61,8 +60,15 @@ public class ConfigTester {
 	static TrackedValue<ValueList<Integer>> TEST_LIST;
 
 	@BeforeAll
-	public static void initializeConfigDir() {
-		ENV = new ConfigEnvironment(TEMP, TomlSerializer.INSTANCE, Json5Serializer.INSTANCE);
+	public static void initializeConfigDir() throws IOException {
+		TestUtil.deleteTempDir();
+
+		ENV = new ConfigEnvironment(TestUtil.TEMP_DIR, TomlSerializer.INSTANCE, Json5Serializer.INSTANCE);
+	}
+
+	@AfterAll
+	public static void deleteConfigDir() throws IOException {
+		TestUtil.deleteTempDir();
 	}
 
 	@Test

--- a/src/test/java/org/quiltmc/config/ConfigTest.java
+++ b/src/test/java/org/quiltmc/config/ConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/quiltmc/config/ReadWriteCycleTest.java
+++ b/src/test/java/org/quiltmc/config/ReadWriteCycleTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.config;
 
 import org.junit.jupiter.api.AfterAll;

--- a/src/test/java/org/quiltmc/config/ReadWriteCycleTest.java
+++ b/src/test/java/org/quiltmc/config/ReadWriteCycleTest.java
@@ -22,13 +22,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.quiltmc.config.api.Config;
 import org.quiltmc.config.api.metadata.MetadataType;
-import org.quiltmc.config.api.serializer.Json5Serializer;
-import org.quiltmc.config.api.serializer.TomlSerializer;
 import org.quiltmc.config.api.values.TrackedValue;
 import org.quiltmc.config.api.values.ValueMap;
 import org.quiltmc.config.api.values.ValueTreeNode;
 import org.quiltmc.config.impl.util.ConfigsImpl;
-import org.quiltmc.config.implementor_api.ConfigEnvironment;
 import org.quiltmc.config.implementor_api.ConfigFactory;
 import org.quiltmc.config.reflective.TestReflectiveConfig;
 
@@ -36,9 +33,6 @@ import java.io.IOException;
 import java.util.Map;
 
 public class ReadWriteCycleTest {
-	private static final ConfigEnvironment TOML_ENV = new ConfigEnvironment(TestUtil.TEMP_DIR, TomlSerializer.INSTANCE);
-	private static final ConfigEnvironment JSON5_ENV = new ConfigEnvironment(TestUtil.TEMP_DIR, Json5Serializer.INSTANCE);
-
 	@BeforeAll
 	public static void initializeConfigDir() throws IOException {
 		TestUtil.deleteTempDir();
@@ -51,19 +45,19 @@ public class ReadWriteCycleTest {
 
 	@Test
 	void testTomlReadWriteCycle() {
-		TestReflectiveConfig config = ConfigFactory.create(TOML_ENV, "testmod", "tomlTestConfig", TestReflectiveConfig.class);
+		TestReflectiveConfig config = ConfigFactory.create(TestUtil.TOML_ENV, "testmod", "tomlTestConfig", TestReflectiveConfig.class);
 		setUpConfig(config);
 
-		TestReflectiveConfig readConfig = ConfigFactory.create(TOML_ENV, "testmod", "tomlTestConfig", TestReflectiveConfig.class);
+		TestReflectiveConfig readConfig = ConfigFactory.create(TestUtil.TOML_ENV, "testmod", "tomlTestConfig", TestReflectiveConfig.class);
 		matchConfigs(config, readConfig);
 	}
 
 	@Test
 	void testJson5ReadWriteCycle() {
-		TestReflectiveConfig config = ConfigFactory.create(JSON5_ENV, "testmod", "json5TestConfig", TestReflectiveConfig.class);
+		TestReflectiveConfig config = ConfigFactory.create(TestUtil.JSON5_ENV, "testmod", "json5TestConfig", TestReflectiveConfig.class);
 		setUpConfig(config);
 
-		TestReflectiveConfig readConfig = ConfigFactory.create(JSON5_ENV, "testmod", "json5TestConfig", TestReflectiveConfig.class);
+		TestReflectiveConfig readConfig = ConfigFactory.create(TestUtil.JSON5_ENV, "testmod", "json5TestConfig", TestReflectiveConfig.class);
 		matchConfigs(config, readConfig);
 	}
 

--- a/src/test/java/org/quiltmc/config/ReadWriteCycleTest.java
+++ b/src/test/java/org/quiltmc/config/ReadWriteCycleTest.java
@@ -1,0 +1,91 @@
+package org.quiltmc.config;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.quiltmc.config.api.Config;
+import org.quiltmc.config.api.metadata.MetadataType;
+import org.quiltmc.config.api.serializer.Json5Serializer;
+import org.quiltmc.config.api.serializer.TomlSerializer;
+import org.quiltmc.config.api.values.TrackedValue;
+import org.quiltmc.config.api.values.ValueTreeNode;
+import org.quiltmc.config.impl.util.ConfigsImpl;
+import org.quiltmc.config.implementor_api.ConfigEnvironment;
+import org.quiltmc.config.implementor_api.ConfigFactory;
+import org.quiltmc.config.reflective.TestReflectiveConfig;
+
+import java.io.IOException;
+import java.util.Map;
+
+public class ReadWriteCycleTest {
+	private static final ConfigEnvironment TOML_ENV = new ConfigEnvironment(TestUtil.TEMP_DIR, TomlSerializer.INSTANCE);
+	private static final ConfigEnvironment JSON5_ENV = new ConfigEnvironment(TestUtil.TEMP_DIR, Json5Serializer.INSTANCE);
+
+	@BeforeAll
+	public static void initializeConfigDir() throws IOException {
+		TestUtil.deleteTempDir();
+	}
+
+	@AfterAll
+	public static void deleteConfigDir() throws IOException {
+		TestUtil.deleteTempDir();
+	}
+
+	@Test
+	void testTomlReadWriteCycle() {
+		TestReflectiveConfig config = ConfigFactory.create(TOML_ENV, "testmod", "tomlTestConfig", TestReflectiveConfig.class);
+		setUpConfig(config);
+
+		TestReflectiveConfig readConfig = ConfigFactory.create(TOML_ENV, "testmod", "tomlTestConfig", TestReflectiveConfig.class);
+		matchConfigs(config, readConfig);
+	}
+
+	@Test
+	void testJson5ReadWriteCycle() {
+		TestReflectiveConfig config = ConfigFactory.create(JSON5_ENV, "testmod", "json5TestConfig", TestReflectiveConfig.class);
+		setUpConfig(config);
+
+		TestReflectiveConfig readConfig = ConfigFactory.create(JSON5_ENV, "testmod", "json5TestConfig", TestReflectiveConfig.class);
+		matchConfigs(config, readConfig);
+	}
+
+	// todo set more nonsense
+	/**
+	 * Sets a bunch of nonsense on the config so that it isn't default: if all values were default we wouldn't be able to tell if they were deserialized or not.
+	 */
+	private void setUpConfig(TestReflectiveConfig config) {
+		config.a.setValue(100, true);
+
+		// remove config from internal map to avoid errors when creating the read config
+		ConfigsImpl.remove(config);
+	}
+
+	// todo include more info in errors
+	/**
+	 * Verifies that both metadata and values match in both configs.
+	 */
+	private void matchConfigs(Config a, Config b) {
+		for (ValueTreeNode aNode : a.nodes()) {
+			ValueTreeNode bNode = b.getNode(aNode.key());
+
+			for (Map.Entry<MetadataType<?, ?>, Object> metadataEntry : aNode.metadata().entrySet()) {
+				if (!bNode.hasMetadata(metadataEntry.getKey())) {
+					throw new RuntimeException("Missing metadata: " + metadataEntry.getKey());
+				} else {
+					Object metadata = bNode.metadata().get(metadataEntry.getKey());
+					if (!metadata.equals(metadataEntry.getValue())) {
+						throw new RuntimeException("Non-equal metadata: " + metadataEntry.getValue());
+					}
+				}
+			}
+
+			if (aNode instanceof TrackedValue<?>)  {
+				TrackedValue<?> aValue = a.getValue(aNode.key());
+				TrackedValue<?> bValue = b.getValue(aNode.key());
+
+				Assertions.assertEquals(aValue.value(), bValue.value());
+			}
+		}
+	}
+}

--- a/src/test/java/org/quiltmc/config/TestSerializerEscaping.java
+++ b/src/test/java/org/quiltmc/config/TestSerializerEscaping.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.config;
 
 import org.junit.jupiter.api.AfterAll;

--- a/src/test/java/org/quiltmc/config/TestSerializerEscaping.java
+++ b/src/test/java/org/quiltmc/config/TestSerializerEscaping.java
@@ -1,0 +1,45 @@
+package org.quiltmc.config;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.quiltmc.config.implementor_api.ConfigFactory;
+import org.quiltmc.config.reflective.TestEscapingConfig;
+
+import java.io.IOException;
+import java.nio.file.Files;
+
+public class TestSerializerEscaping {
+	@BeforeAll
+	public static void initializeConfigDir() throws IOException {
+		TestUtil.deleteTempDir();
+	}
+
+	@AfterAll
+	public static void deleteConfigDir() throws IOException {
+		TestUtil.deleteTempDir();
+	}
+
+	@Test
+	void testTomlReadWriteCycle() throws IOException {
+		TestEscapingConfig config = ConfigFactory.create(TestUtil.TOML_ENV, "testmod", "tomlEscapingTestConfig", TestEscapingConfig.class);
+		config.save();
+
+		String content = new String(Files.readAllBytes(TestUtil.TEMP_DIR.resolve("testmod").resolve("tomlEscapingTestConfig.toml")));
+		Assertions.assertTrue(content.contains("[\"servers.server.served\"]"), "File contents did not contain proper map key (expected '[\"servers.server.served\"]')!\ncontents:\n" + content);
+		Assertions.assertTrue(content.contains("\"gaming.awesome\""), "File contents did not contain proper string key (expected '\"gaming.awesome\"')!\ncontents:\n" + content);
+		Assertions.assertTrue(content.contains("\"cool.awesome@list[]neat\""), "File contents did not contain proper list key (expected '\"cool.awesome@list[]neat\"')!\ncontents:\n" + content);
+	}
+
+	@Test
+	void testJson5ReadWriteCycle() throws IOException {
+		TestEscapingConfig config = ConfigFactory.create(TestUtil.JSON5_ENV, "testmod", "json5EscapingTestConfig", TestEscapingConfig.class);
+		config.save();
+
+		String content = new String(Files.readAllBytes(TestUtil.TEMP_DIR.resolve("testmod").resolve("json5EscapingTestConfig.json5")));
+		Assertions.assertTrue(content.contains("\"servers.server.served\":"), "File contents did not contain proper map key (expected '\"servers.server.served\":')!\ncontents:\n" + content);
+		Assertions.assertTrue(content.contains("\"gaming.awesome\":"), "File contents did not contain proper string key (expected '\"gaming.awesome\":')!\ncontents:\n" + content);
+		Assertions.assertTrue(content.contains("\"cool.awesome@list[]neat\":"), "File contents did not contain proper list key (expected '\"cool.awesome@list[]neat\":')!\ncontents:\n" + content);
+	}
+}

--- a/src/test/java/org/quiltmc/config/TestUtil.java
+++ b/src/test/java/org/quiltmc/config/TestUtil.java
@@ -1,0 +1,26 @@
+package org.quiltmc.config;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class TestUtil {
+	static final Path TEMP_DIR = Paths.get("temp");
+
+	static void deleteTempDir() throws IOException {
+		deleteDirectoryRecursively(TEMP_DIR.toFile());
+	}
+
+	private static void deleteDirectoryRecursively(File toBeDeleted) throws IOException {
+		File[] allContents = toBeDeleted.listFiles();
+		if (allContents != null) {
+			for (File file : allContents) {
+				deleteDirectoryRecursively(file);
+			}
+		}
+
+		Files.deleteIfExists(toBeDeleted.toPath());
+	}
+}

--- a/src/test/java/org/quiltmc/config/TestUtil.java
+++ b/src/test/java/org/quiltmc/config/TestUtil.java
@@ -16,6 +16,10 @@
 
 package org.quiltmc.config;
 
+import org.quiltmc.config.api.serializer.Json5Serializer;
+import org.quiltmc.config.api.serializer.TomlSerializer;
+import org.quiltmc.config.implementor_api.ConfigEnvironment;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -24,6 +28,8 @@ import java.nio.file.Paths;
 
 public class TestUtil {
 	static final Path TEMP_DIR = Paths.get("temp");
+	static final ConfigEnvironment TOML_ENV = new ConfigEnvironment(TestUtil.TEMP_DIR, TomlSerializer.INSTANCE);
+	static final ConfigEnvironment JSON5_ENV = new ConfigEnvironment(TestUtil.TEMP_DIR, Json5Serializer.INSTANCE);
 
 	static void deleteTempDir() throws IOException {
 		deleteDirectoryRecursively(TEMP_DIR.toFile());

--- a/src/test/java/org/quiltmc/config/TestUtil.java
+++ b/src/test/java/org/quiltmc/config/TestUtil.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.config;
 
 import java.io.File;

--- a/src/test/java/org/quiltmc/config/Vec3i.java
+++ b/src/test/java/org/quiltmc/config/Vec3i.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/quiltmc/config/Vec3i.java
+++ b/src/test/java/org/quiltmc/config/Vec3i.java
@@ -20,6 +20,8 @@ import org.quiltmc.config.api.values.ComplexConfigValue;
 import org.quiltmc.config.api.values.ConfigSerializableObject;
 import org.quiltmc.config.api.values.ValueMap;
 
+import java.util.Objects;
+
 public class Vec3i implements ConfigSerializableObject<ValueMap<Integer>> {
 	public final int x, y, z;
 
@@ -46,5 +48,18 @@ public class Vec3i implements ConfigSerializableObject<ValueMap<Integer>> {
 				.put("y", this.y)
 				.put("z", this.z)
 				.build();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		Vec3i vec3i = (Vec3i) o;
+		return x == vec3i.x && y == vec3i.y && z == vec3i.z;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(x, y, z);
 	}
 }

--- a/src/test/java/org/quiltmc/config/reflective/TestEscapingConfig.java
+++ b/src/test/java/org/quiltmc/config/reflective/TestEscapingConfig.java
@@ -1,0 +1,20 @@
+package org.quiltmc.config.reflective;
+
+import org.quiltmc.config.api.ReflectiveConfig;
+import org.quiltmc.config.api.annotations.SerializedName;
+import org.quiltmc.config.api.values.TrackedValue;
+import org.quiltmc.config.api.values.ValueList;
+import org.quiltmc.config.api.values.ValueMap;
+
+public class TestEscapingConfig extends ReflectiveConfig {
+	@SerializedName("gaming.awesome")
+	public final TrackedValue<String> awesome = this.value("gaming@1");
+
+	@SerializedName("servers.server.served")
+	public final TrackedValue<ValueMap<String>> servers = this.value(
+		ValueMap.builder("").put("s@dir/otherdir/thirddir", "rai minecraft").put("m@www.raiminecraft.com", "minecraft").build());
+
+	@SerializedName("cool.awesome@list[]neat")
+	public final TrackedValue<ValueList<String>> awesomeList = this.value(
+		ValueList.create("", "gkjasdkjfghsa^&%^&...gsd"));
+}

--- a/src/test/java/org/quiltmc/config/reflective/TestEscapingConfig.java
+++ b/src/test/java/org/quiltmc/config/reflective/TestEscapingConfig.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.config.reflective;
 
 import org.quiltmc.config.api.ReflectiveConfig;

--- a/src/test/java/org/quiltmc/config/reflective/TestReflectiveConfig.java
+++ b/src/test/java/org/quiltmc/config/reflective/TestReflectiveConfig.java
@@ -28,6 +28,9 @@ import org.quiltmc.config.api.values.TrackedValue;
 import org.quiltmc.config.api.values.ValueList;
 import org.quiltmc.config.api.values.ValueMap;
 
+/**
+ * A test config designed to use absolutely every single possible feature.
+ */
 @Processor("processConfig")
 public final class TestReflectiveConfig extends ReflectiveConfig {
 	@Comment({"Comment one", "Comment two"})

--- a/src/test/java/org/quiltmc/config/reflective/TestReflectiveConfig.java
+++ b/src/test/java/org/quiltmc/config/reflective/TestReflectiveConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/quiltmc/config/reflective/TestReflectiveConfig2.java
+++ b/src/test/java/org/quiltmc/config/reflective/TestReflectiveConfig2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/quiltmc/config/reflective/TestValueConfig3.java
+++ b/src/test/java/org/quiltmc/config/reflective/TestValueConfig3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/quiltmc/config/reflective/TestValueConfig4.java
+++ b/src/test/java/org/quiltmc/config/reflective/TestValueConfig4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/quiltmc/config/reflective/TestValueListConfig.java
+++ b/src/test/java/org/quiltmc/config/reflective/TestValueListConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/quiltmc/config/reflective/TestValueMapConfig.java
+++ b/src/test/java/org/quiltmc/config/reflective/TestValueMapConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
hopefully the last pr of the 1.2 cycle. adds extensive testing for read/write cycle to ensure no data is lost during reading or writing
fixes #19 

contains one API addition: `MetadataContainer#metadata()`
```java

         /**
	 * @return a map of all metadata attached to this node
	 */
	Map<MetadataType<?, ?>, Object> metadata();
```

TODO:
- [x] add tests that simply read the file and compare against a string, to ensure formatting is proper - decided against doing this
- [x] expand read/write tests

notes:
- diff is huge because it's 2024 and licenses need updating
- shouldn't change functionality of anything. I haven't found any issues in writing these tests (so far)