### PR TITLE
override metadata() in WrappedConfig as well

### DIFF
--- a/src/main/java/org/quiltmc/config/api/WrappedConfig.java
+++ b/src/main/java/org/quiltmc/config/api/WrappedConfig.java
@@ -22,6 +22,7 @@ import org.quiltmc.config.api.values.TrackedValue;
 import org.quiltmc.config.api.values.ValueTreeNode;
 
 import java.nio.file.Path;
+import java.util.Map;
 
 
 /**
@@ -59,6 +60,11 @@ public abstract class WrappedConfig implements Config {
 	@Override
 	public final <M> boolean hasMetadata(MetadataType<M, ?> type) {
 		return this.wrapped.hasMetadata(type);
+	}
+
+	@Override
+	public Map<MetadataType<?, ?>, Object> metadata() {
+		return this.wrapped.metadata();
 	}
 
 	@Override


### PR DESCRIPTION
Hello! local devout WrappedConfig user here. 

Big fan of serializers being included in the project instead of in quilt loader by the way! We've been shadowing quilt config to make it loader agnostic for a while and that move cut our project size down to a quarter of what it was.

Anyway, wrapped config impls fail on latest because they don't and can't implement `metadata()`, so we fixed it to work the same way reflective does.