### PR TITLE
reintroduce tests for wrapped config

### DIFF
--- a/src/test/java/org/quiltmc/config/TestUtil.java
+++ b/src/test/java/org/quiltmc/config/TestUtil.java
@@ -27,11 +27,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 public class TestUtil {
-	static final Path TEMP_DIR = Paths.get("temp");
-	static final ConfigEnvironment TOML_ENV = new ConfigEnvironment(TestUtil.TEMP_DIR, TomlSerializer.INSTANCE);
-	static final ConfigEnvironment JSON5_ENV = new ConfigEnvironment(TestUtil.TEMP_DIR, Json5Serializer.INSTANCE);
+	public static final Path TEMP_DIR = Paths.get("temp");
+	public static final ConfigEnvironment TOML_ENV = new ConfigEnvironment(TestUtil.TEMP_DIR, TomlSerializer.INSTANCE);
+	public static final ConfigEnvironment JSON5_ENV = new ConfigEnvironment(TestUtil.TEMP_DIR, Json5Serializer.INSTANCE);
 
-	static void deleteTempDir() throws IOException {
+	public static void deleteTempDir() throws IOException {
 		deleteDirectoryRecursively(TEMP_DIR.toFile());
 	}
 

--- a/src/test/java/org/quiltmc/config/old_wrapped/ConfigTest.java
+++ b/src/test/java/org/quiltmc/config/old_wrapped/ConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 QuiltMC
+ * Copyright 2022-2023 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package org.quiltmc.config;
+package org.quiltmc.config.old_wrapped;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -24,8 +23,6 @@ import org.quiltmc.config.api.Config;
 import org.quiltmc.config.api.ConfigEnvironment;
 import org.quiltmc.config.api.Constraint;
 import org.quiltmc.config.api.annotations.Comment;
-import org.quiltmc.config.api.annotations.SerializedName;
-import org.quiltmc.config.api.exceptions.ConfigCreationException;
 import org.quiltmc.config.api.exceptions.ConfigFieldException;
 import org.quiltmc.config.api.exceptions.TrackedValueException;
 import org.quiltmc.config.api.metadata.Comments;
@@ -36,21 +33,22 @@ import org.quiltmc.config.api.values.TrackedValue;
 import org.quiltmc.config.api.values.ValueList;
 import org.quiltmc.config.api.values.ValueMap;
 import org.quiltmc.config.impl.CommentsImpl;
-import org.quiltmc.config.implementor_api.ConfigFactory;
-import org.quiltmc.config.reflective.TestValueConfig3;
-import org.quiltmc.config.reflective.TestValueConfig4;
-import org.quiltmc.config.reflective.TestValueListConfig;
-import org.quiltmc.config.reflective.TestValueMapConfig;
-import org.quiltmc.config.reflective.TestReflectiveConfig;
-import org.quiltmc.config.reflective.TestReflectiveConfig2;
+import org.quiltmc.config.old_wrapped.input.TestValueConfig3;
+import org.quiltmc.config.old_wrapped.input.TestValueConfig4;
+import org.quiltmc.config.old_wrapped.input.TestValueListConfig;
+import org.quiltmc.config.old_wrapped.input.TestValueMapConfig;
+import org.quiltmc.config.old_wrapped.input.TestWrappedConfig;
+import org.quiltmc.config.old_wrapped.input.TestWrappedConfig2;
 
-import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Optional;
 
-@SuppressWarnings("deprecation")
+@SuppressWarnings({"deprecation", "unused"})
 public class ConfigTest {
+	static Path TEMP = Paths.get("temp");
 	static ConfigEnvironment ENV;
 
 	static TrackedValue<String> TEST;
@@ -60,15 +58,8 @@ public class ConfigTest {
 	static TrackedValue<ValueList<Integer>> TEST_LIST;
 
 	@BeforeAll
-	public static void initializeConfigDir() throws IOException {
-		TestUtil.deleteTempDir();
-
-		ENV = new ConfigEnvironment(TestUtil.TEMP_DIR, TomlSerializer.INSTANCE, Json5Serializer.INSTANCE);
-	}
-
-	@AfterAll
-	public static void deleteConfigDir() throws IOException {
-		TestUtil.deleteTempDir();
+	public static void initializeConfigDir() {
+		ENV = new ConfigEnvironment(TEMP, TomlSerializer.INSTANCE, Json5Serializer.INSTANCE);
 	}
 
 	@Test
@@ -81,10 +72,8 @@ public class ConfigTest {
 			}));
 			builder.section("super_awesome_section", section1 -> {
 				section1.metadata(Comment.TYPE, comments -> comments.add("This is a section comment!"));
-				section1.metadata(SerializedName.TYPE, name -> name.withName("super_duper_awesome_section"));
 				section1.field(TrackedValue.create(1, "before"));
 				section1.section("less_awesome_section", section2 -> {
-					section2.metadata(SerializedName.TYPE, name -> name.withName("much_less_awesome_section"));
 					section2.metadata(Comment.TYPE, comments -> comments.add("This is another section comment!"));
 					section2.section("regular_section", section3 -> {
 						section3.field(TrackedValue.create(0, "water"));
@@ -121,9 +110,17 @@ public class ConfigTest {
 
 	@Test
 	public void testValidation() {
-		Assertions.assertThrows(TrackedValueException.class, () -> Config.create(ENV, "testmod", "testConfig1", builder -> builder.field(TrackedValue.create(new ArrayList<Integer>(), "boop"))));
+		Assertions.assertThrows(TrackedValueException.class, () -> {
+			Config.create(ENV, "testmod", "testConfig1", builder -> {
+				builder.field(TrackedValue.create(new ArrayList<Integer>(), "boop"));
+			});
+		});
 
-		Assertions.assertThrows(TrackedValueException.class, () -> Config.create(ENV, "testmod", "testConfig2", builder -> builder.field(TrackedValue.create(ValueList.create(new ArrayList<Integer>()), "boop"))));
+		Assertions.assertThrows(TrackedValueException.class, () -> {
+			Config.create(ENV, "testmod", "testConfig2", builder -> {
+				builder.field(TrackedValue.create(ValueList.create(new ArrayList<Integer>()), "boop"));
+			});
+		});
 	}
 
 	@Test
@@ -142,7 +139,9 @@ public class ConfigTest {
 				section.field(TrackedValue.create("wooooh", "emote"));
 				section.field(TrackedValue.create("etrator", "perp"));
 			});
-			builder.callback(c -> System.out.println("We was updated!"));
+			builder.callback(c -> {
+				System.out.println("We was updated!");
+			});
 		});
 
 		TEST_STRING.registerCallback((value) ->
@@ -165,11 +164,13 @@ public class ConfigTest {
 	@Test
 	public void testMetadata() {
 		Config config = Config.create(ENV, "testmod", "testConfig4", builder -> {
-			builder.field(TEST_INTEGER = TrackedValue.create(0, "testInteger", creator -> creator.metadata(Comment.TYPE, comments -> comments.add(
-					"Comment one",
-					"Comment two",
-					"Comment three"
-			))));
+			builder.field(TEST_INTEGER = TrackedValue.create(0, "testInteger", creator -> {
+				creator.metadata(Comment.TYPE, comments -> comments.add(
+						"Comment one",
+						"Comment two",
+						"Comment three"
+				));
+			}));
 			builder.field(TEST_BOOLEAN = TrackedValue.create(false, "testBoolean"));
 			builder.field(TEST_STRING  = TrackedValue.create("blah", "testString"));
 		});
@@ -213,7 +214,9 @@ public class ConfigTest {
 
 		Assertions.assertThrows(TrackedValueException.class, () -> {
 			Config.create(ENV, "testmod", "testConfig7", builder -> {
-				builder.field(TEST_INTEGER = TrackedValue.create(0, "testInteger", creator -> creator.constraint(Constraint.range(-10, 10))));
+				builder.field(TEST_INTEGER = TrackedValue.create(0, "testInteger", creator -> {
+					creator.constraint(Constraint.range(-10, 10));
+				}));
 				builder.field(TEST_BOOLEAN = TrackedValue.create(false, "testBoolean"));
 				builder.field(TEST_STRING  = TrackedValue.create("blah", "testString"));
 			});
@@ -223,23 +226,33 @@ public class ConfigTest {
 
 		Assertions.assertThrows(TrackedValueException.class, () -> {
 			Config.create(ENV, "testmod", "testConfig8", builder -> {
-				builder.field(TEST_INTEGER = TrackedValue.create(0, "testInteger", creator -> creator.constraint(Constraint.range(-10, 10))));
+				builder.field(TEST_INTEGER = TrackedValue.create(0, "testInteger", creator -> {
+					creator.constraint(Constraint.range(-10, 10));
+				}));
 				builder.field(TEST_BOOLEAN = TrackedValue.create(false, "testBoolean"));
-				builder.field(TEST_STRING  = TrackedValue.create("blah", "test", creator -> creator.constraint(Constraint.matching("[a-zA-Z0-9]+:[a-zA-Z0-9]+"))));
+				builder.field(TEST_STRING  = TrackedValue.create("blah", "test", creator -> {
+					creator.constraint(Constraint.matching("[a-zA-Z0-9]+:[a-zA-Z0-9]+"));
+				}));
 			});
 
 			TEST_INTEGER.setValue(1000, true);
 		});
 
 		Config.create(ENV, "testmod", "testConfig9", builder -> {
-			builder.field(TEST_INTEGER = TrackedValue.create(0, "testInteger", creator -> creator.constraint(Constraint.range(-10, 10))));
+			builder.field(TEST_INTEGER = TrackedValue.create(0, "testInteger", creator -> {
+				creator.constraint(Constraint.range(-10, 10));
+			}));
 			builder.field(TEST_BOOLEAN = TrackedValue.create(false, "testBoolean"));
-			builder.field(TEST_STRING  = TrackedValue.create("test:id", "test", creator -> creator.constraint(Constraint.matching("[a-zA-Z0-9]+:[a-zA-Z0-9]+"))));
+			builder.field(TEST_STRING  = TrackedValue.create("test:id", "test", creator -> {
+				creator.constraint(Constraint.matching("[a-zA-Z0-9]+:[a-zA-Z0-9]+"));
+			}));
 		});
 	}
 
 	public void testWrappedConfigs(String id, String format) {
-		TestReflectiveConfig config = ConfigFactory.create(ENV, "testmod", id, TestReflectiveConfig.class, builder -> builder.format(format));
+		TestWrappedConfig config = Config.create(ENV, "testmod", id, TestWrappedConfig.class, builder -> {
+			builder.format(format);
+		});
 
 		for (TrackedValue<?> value : config.values()) {
 			System.out.printf("\"%s\": %s%n", value.key(), value.value());
@@ -249,11 +262,17 @@ public class ConfigTest {
 			}
 		}
 
-		Assertions.assertThrows(ConfigCreationException.class, () -> ConfigFactory.create(ENV, "testmod", "testConfig", TestReflectiveConfig2.class)).printStackTrace();
+		Assertions.assertThrows(ConfigFieldException.class, () -> {
+			Config.create(ENV, "testmod", "testConfig", TestWrappedConfig2.class);
+		}).printStackTrace();
 
-		Assertions.assertThrows(ConfigFieldException.class, () -> ConfigFactory.create(ENV, "testmod", "testConfig", TestValueConfig3.class)).printStackTrace();
+		Assertions.assertThrows(ConfigFieldException.class, () -> {
+			Config.create(ENV, "testmod", "testConfig", TestValueConfig3.class);
+		}).printStackTrace();
 
-		Assertions.assertThrows(TrackedValueException.class, () -> ConfigFactory.create(ENV, "testmod", "testConfig", TestValueConfig4.class)).printStackTrace();
+		Assertions.assertThrows(TrackedValueException.class, () -> {
+			Config.create(ENV, "testmod", "testConfig", TestValueConfig4.class);
+		}).printStackTrace();
 	}
 
 	@Test
@@ -264,7 +283,9 @@ public class ConfigTest {
 
 	@Test
 	public void testTomlConfigs() {
-		TestReflectiveConfig config = ConfigFactory.create(ENV, "testmod", "testConfig12", TestReflectiveConfig.class, builder -> builder.format("toml"));
+		TestWrappedConfig config = Config.create(ENV, "testmod", "testConfig12", TestWrappedConfig.class, builder -> {
+			builder.format("toml");
+		});
 
 		for (TrackedValue<?> value : config.values()) {
 			System.out.printf("\"%s\": %s%n", value.key(), value.value());
@@ -277,16 +298,16 @@ public class ConfigTest {
 
 	@Test
 	public void testValueMapBehavior() {
-		TestValueMapConfig c = ConfigFactory.create(ENV, "testmod", "testConfig13", TestValueMapConfig.class);
+		TestValueMapConfig c = Config.create(ENV, "testmod", "testConfig13", TestValueMapConfig.class);
 
-		c.weights.value().put("" + c.weights.value().size(), c.weights.value().size());
+		c.weights.put("" + c.weights.size(), c.weights.size());
 	}
 
 	@Test
 	public void testValueListBehavior() {
-		TestValueListConfig c = ConfigFactory.create(ENV, "testmod", "testConfig14", TestValueListConfig.class);
+		TestValueListConfig c = Config.create(ENV, "testmod", "testConfig14", TestValueListConfig.class);
 
-		c.strings.value().add(c.strings.value().size() + "");
+		c.strings.add(c.strings.size() + "");
 	}
 
 	@Test
@@ -300,11 +321,13 @@ public class ConfigTest {
 		}, Comment.Builder::new);
 
 		Config config = Config.create(ENV, "testmod", "testConfig400", builder -> {
-			builder.field(TEST_INTEGER = TrackedValue.create(0, "testInteger", creator -> creator.metadata(TYPE, comments -> comments.add(
-					"Comment one",
-					"Comment two",
-					"Comment three"
-			))));
+			builder.field(TEST_INTEGER = TrackedValue.create(0, "testInteger", creator -> {
+				creator.metadata(TYPE, comments -> comments.add(
+						"Comment one",
+						"Comment two",
+						"Comment three"
+				));
+			}));
 			builder.field(TEST_BOOLEAN = TrackedValue.create(false, "testBoolean"));
 			builder.field(TEST_STRING  = TrackedValue.create("blah", "testString"));
 		});

--- a/src/test/java/org/quiltmc/config/old_wrapped/input/TestValueConfig3.java
+++ b/src/test/java/org/quiltmc/config/old_wrapped/input/TestValueConfig3.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022-2023 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.config.old_wrapped.input;
+
+import org.quiltmc.config.Vec3i;
+import org.quiltmc.config.api.WrappedConfig;
+import org.quiltmc.config.api.annotations.Comment;
+import org.quiltmc.config.api.annotations.FloatRange;
+import org.quiltmc.config.api.values.ValueList;
+import org.quiltmc.config.api.values.ValueMap;
+
+public final class TestValueConfig3 extends WrappedConfig {
+	@Comment({"Comment one", "Comment two"})
+	public final int a = 0;
+	public final int b = 1;
+	public final int c = 2;
+	@FloatRange(min=0, max=10)
+	public final int d = 3;
+	public final Vec3i vec = new Vec3i(100, 200, 300);
+	public final String whatever = "Riesling";
+	public final Nested nested1 = new Nested(10, 11, 12, 13);
+	public final Nested nested3 = new Nested(20, 21, 22, 23);
+	public final ValueList<Vec3i> vecs = ValueList.create(new Vec3i(0, 0, 0),
+			new Vec3i(1, 2, 3),
+			new Vec3i(4, 5, 6),
+			new Vec3i(7, 8, 9)
+	);
+
+	@Comment("Test section comment")
+	public final Nested nested4 = new Nested(30, 31, 32, 33);
+
+	public final ValueList<ValueMap<Integer>> listOfNestedObjects = ValueList.create(ValueMap.builder(0).build(),
+			ValueMap.builder(0).put("a", 1).put("b", 2).put("c", 3).put("d", 4).build(),
+			ValueMap.builder(0).put("a", 1).put("b", 2).put("c", 3).put("d", 4).build(),
+			ValueMap.builder(0).put("a", 1).put("b", 2).put("c", 3).put("d", 4).build()
+	);
+
+	public static final class Nested {
+		public final int a;
+		public final int b;
+		public final int c;
+		public final int d;
+
+		public Nested(int a, int b, int c, int d) {
+			this.a = a;
+			this.b = b;
+			this.c = c;
+			this.d = d;
+		}
+	}
+}

--- a/src/test/java/org/quiltmc/config/old_wrapped/input/TestValueConfig4.java
+++ b/src/test/java/org/quiltmc/config/old_wrapped/input/TestValueConfig4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 QuiltMC
+ * Copyright 2022-2023 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,36 +14,34 @@
  * limitations under the License.
  */
 
-package org.quiltmc.config.reflective;
+package org.quiltmc.config.old_wrapped.input;
 
 import org.quiltmc.config.Vec3i;
-import org.quiltmc.config.api.ReflectiveConfig;
+import org.quiltmc.config.api.WrappedConfig;
 import org.quiltmc.config.api.annotations.Comment;
 import org.quiltmc.config.api.annotations.IntegerRange;
 import org.quiltmc.config.api.annotations.Matches;
-import org.quiltmc.config.api.annotations.SerializedName;
-import org.quiltmc.config.api.values.TrackedValue;
 import org.quiltmc.config.api.values.ValueList;
 import org.quiltmc.config.api.values.ValueMap;
 
-public final class TestValueConfig4 extends ReflectiveConfig {
+public final class TestValueConfig4 extends WrappedConfig {
 	@Comment({"Comment one", "Comment two"})
-	public final TrackedValue<Integer> a = this.value(0);
+	public final int a = 0;
 
 	@Comment("Comment one")
 	@Comment("Comment two")
-	public final TrackedValue<Integer> b = this.value(1);
-	public final TrackedValue<Integer> c = this.value(2);
+	public final int b = 1;
+	public final int c = 2;
 
 	@IntegerRange(min=0, max=10)
-	public final TrackedValue<Integer> d = this.value(3);
-	public final TrackedValue<Vec3i> vec = this.value(new Vec3i(100, 200, 300));
+	public final int d = 3;
+	public final Vec3i vec = new Vec3i(100, 200, 300);
 
 	@Matches("[a-zA-Z]+")
-	public final TrackedValue<String> whatever = this.value("01234");
-	public final Nested nested1 = new Nested();
-	public final Nested nested3 = new Nested();
-	public final TrackedValue<ValueList<Vec3i>> vecs = this.list(new Vec3i(0, 0, 0),
+	public final String whatever = "01234";
+	public final Nested nested1 = new Nested(10, 11, 12, 13);
+	public final Nested nested3 = new Nested(20, 21, 22, 23);
+	public final ValueList<Vec3i> vecs = ValueList.create(new Vec3i(0, 0, 0),
 			new Vec3i(1, 2, 3),
 			new Vec3i(4, 5, 6),
 			new Vec3i(7, 8, 9)
@@ -53,22 +51,28 @@ public final class TestValueConfig4 extends ReflectiveConfig {
 	@Comment("Test section comment 2")
 	@Comment("Test section comment 3")
 	@Comment("Test section comment 4")
-	public final Nested nested4 = new Nested();
+	public final Nested nested4 = new Nested(30, 31, 32, 33);
 
 	@IntegerRange(min=0, max=10)
-	public final TrackedValue<ValueList<Integer>> ints = this.list(0, 1, 2, 3, 4);
+	public final ValueList<Integer> ints = ValueList.create(0, 1, 2, 3, 4);
 
-	public final TrackedValue<ValueList<ValueMap<Integer>>> listOfNestedObjects = this.list(ValueMap.builder(0).build(),
+	public final ValueList<ValueMap<Integer>> listOfNestedObjects = ValueList.create(ValueMap.builder(0).build(),
 			ValueMap.builder(0).put("a", 1).put("b", 2).put("c", 3).put("d", 4).build(),
 			ValueMap.builder(0).put("a", 1).put("b", 2).put("c", 3).put("d", 4).build(),
 			ValueMap.builder(0).put("a", 1).put("b", 2).put("c", 3).put("d", 4).build()
 	);
 
-	public static final class Nested extends Section {
-		@SerializedName("custom_serialized_name_a")
-		public final TrackedValue<Integer> a = this.value(0);
-		public final TrackedValue<Integer> b = this.value(1);
-		public final TrackedValue<Integer> c = this.value(2);
-		public final TrackedValue<Integer> d = this.value(3);
+	public static final class Nested implements Section {
+		public final int a;
+		public final int b;
+		public final int c;
+		public final int d;
+
+		public Nested(int a, int b, int c, int d) {
+			this.a = a;
+			this.b = b;
+			this.c = c;
+			this.d = d;
+		}
 	}
 }

--- a/src/test/java/org/quiltmc/config/old_wrapped/input/TestValueListConfig.java
+++ b/src/test/java/org/quiltmc/config/old_wrapped/input/TestValueListConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 QuiltMC
+ * Copyright 2022-2023 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-package org.quiltmc.config.reflective;
+package org.quiltmc.config.old_wrapped.input;
 
-import org.quiltmc.config.api.ReflectiveConfig;
-import org.quiltmc.config.api.values.TrackedValue;
+import org.quiltmc.config.api.WrappedConfig;
 import org.quiltmc.config.api.values.ValueList;
 
-public class TestValueListConfig extends ReflectiveConfig {
-	public final TrackedValue<String> test = this.value("watermark");
-	public final TrackedValue<Integer> thingy = this.value(1009);
-	public final TrackedValue<ValueList<String>> strings = this.list("");
+public class TestValueListConfig extends WrappedConfig {
+	public final String test = "watermark";
+	public final int thingy = 1009;
+	public final ValueList<String> strings = ValueList.create("");
 }

--- a/src/test/java/org/quiltmc/config/old_wrapped/input/TestValueMapConfig.java
+++ b/src/test/java/org/quiltmc/config/old_wrapped/input/TestValueMapConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 QuiltMC
+ * Copyright 2022-2023 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-package org.quiltmc.config.reflective;
+package org.quiltmc.config.old_wrapped.input;
 
-import org.quiltmc.config.api.ReflectiveConfig;
-import org.quiltmc.config.api.values.TrackedValue;
+import org.quiltmc.config.api.WrappedConfig;
 import org.quiltmc.config.api.values.ValueMap;
 
-public class TestValueMapConfig extends ReflectiveConfig {
-	public final TrackedValue<Integer> version = this.value(100);
-	public final TrackedValue<String> flavor = this.value("lemon");
-	public final TrackedValue<ValueMap<Integer>> weights = this.map(0).build();
+public class TestValueMapConfig extends WrappedConfig {
+	public final int version = 100;
+	public final String flavor = "lemon";
+	public final ValueMap<Integer> weights = ValueMap.builder(0).build();
 }

--- a/src/test/java/org/quiltmc/config/old_wrapped/input/TestWrappedConfig.java
+++ b/src/test/java/org/quiltmc/config/old_wrapped/input/TestWrappedConfig.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2022-2023 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.config.old_wrapped.input;
+
+import org.quiltmc.config.Vec3i;
+import org.quiltmc.config.api.WrappedConfig;
+import org.quiltmc.config.api.annotations.Comment;
+import org.quiltmc.config.api.annotations.IntegerRange;
+import org.quiltmc.config.api.annotations.Matches;
+import org.quiltmc.config.api.annotations.Processor;
+import org.quiltmc.config.api.values.TrackedValue;
+import org.quiltmc.config.api.values.ValueList;
+import org.quiltmc.config.api.values.ValueMap;
+
+@Processor("processConfig")
+public final class TestWrappedConfig extends WrappedConfig {
+	@Comment({"Comment one", "Comment two"})
+	public final int a = 0;
+
+	@Comment("Comment one")
+	@Comment("Comment two")
+	public final int b = 1;
+	public final int c = 2;
+
+	@IntegerRange(min=0, max=10)
+	public final int d = 3;
+	public final Vec3i vec = new Vec3i(100, 200, 300);
+
+	@Matches("[a-zA-Z]+")
+	public final String whatever = "Riesling";
+	public final Nested nested1 = new Nested(10, 11, 12, 13);
+	public final Nested nested3 = new Nested(20, 21, 22, 23);
+
+	public final ValueList<String> enabled = ValueList.create("");
+
+	@Processor("processField")
+	public final ValueList<Vec3i> vecs = ValueList.create(new Vec3i(0, 0, 0),
+			new Vec3i(1, 2, 3),
+			new Vec3i(4, 5, 6),
+			new Vec3i(7, 8, 9)
+	);
+
+	@Comment("Test section comment 1")
+	@Comment("Test section comment 2")
+	@Comment("Test section comment 3")
+	@Comment("Test section comment 4")
+	public final Nested nested4 = new Nested(30, 31, 32, 33);
+
+	public final ValueMap<ValueList<String>> key_binds = ValueMap.builder(ValueList.create("")).build();
+
+	@IntegerRange(min=0, max=10)
+	public final ValueList<Integer> ints = ValueList.create(0, 1, 2, 3, 4);
+
+	public final ValueList<ValueMap<Integer>> listOfNestedObjects = ValueList.create(ValueMap.builder(0).build(),
+			ValueMap.builder(0).put("a", 1).put("b", 2).put("c", 3).put("d", 4).build(),
+			ValueMap.builder(0).put("a", 1).put("b", 2).put("c", 3).put("d", 4).build(),
+			ValueMap.builder(0).put("a", 1).put("b", 2).put("c", 3).put("d", 4).build()
+	);
+
+	public void processConfig(Builder builder) {
+		System.out.println("Processing config!");
+	}
+
+	public void processField(TrackedValue.Builder<Vec3i> process) {
+		System.out.println("Processing field!");
+	}
+
+	public static final class Nested implements Section {
+		public final int a;
+		public final int b;
+		public final int c;
+		public final int d;
+
+		public Nested(int a, int b, int c, int d) {
+			this.a = a;
+			this.b = b;
+			this.c = c;
+			this.d = d;
+		}
+	}
+}

--- a/src/test/java/org/quiltmc/config/old_wrapped/input/TestWrappedConfig2.java
+++ b/src/test/java/org/quiltmc/config/old_wrapped/input/TestWrappedConfig2.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022-2023 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.config.old_wrapped.input;
+
+import org.quiltmc.config.api.WrappedConfig;
+import org.quiltmc.config.api.annotations.Comment;
+import org.quiltmc.config.api.values.ValueList;
+import org.quiltmc.config.api.values.ValueMap;
+
+public final class TestWrappedConfig2 extends WrappedConfig {
+	@Comment({"Comment one", "Comment two"})
+	public final int a = 0;
+	public final int b = 1;
+	public final int c = 2;
+	public final int d = 3;
+	public final String whatever = null;
+	public final Nested nested1 = new Nested(10, 11, 12, 13);
+	public final Nested nested3 = new Nested(20, 21, 22, 23);
+	public final Nested nested4 = new Nested(30, 31, 32, 33);
+
+	public final ValueList<ValueMap<Integer>> listOfNestedObjects = ValueList.create(ValueMap.builder(0).build(),
+			ValueMap.builder(0).put("a", 1).put("b", 2).put("c", 3).put("d", 4).build(),
+			ValueMap.builder(0).put("a", 1).put("b", 2).put("c", 3).put("d", 4).build(),
+			ValueMap.builder(0).put("a", 1).put("b", 2).put("c", 3).put("d", 4).build()
+	);
+
+	public static final class Nested {
+		public final int a;
+		public final int b;
+		public final int c;
+		public final int d;
+
+		public Nested(int a, int b, int c, int d) {
+			this.a = a;
+			this.b = b;
+			this.c = c;
+			this.d = d;
+		}
+	}
+}

--- a/src/test/java/org/quiltmc/config/reflective/ConfigTest.java
+++ b/src/test/java/org/quiltmc/config/reflective/ConfigTest.java
@@ -1,0 +1,319 @@
+/*
+ * Copyright 2022-2024 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.config.reflective;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.quiltmc.config.TestUtil;
+import org.quiltmc.config.api.Config;
+import org.quiltmc.config.api.ConfigEnvironment;
+import org.quiltmc.config.api.Constraint;
+import org.quiltmc.config.api.annotations.Comment;
+import org.quiltmc.config.api.annotations.SerializedName;
+import org.quiltmc.config.api.exceptions.ConfigCreationException;
+import org.quiltmc.config.api.exceptions.ConfigFieldException;
+import org.quiltmc.config.api.exceptions.TrackedValueException;
+import org.quiltmc.config.api.metadata.Comments;
+import org.quiltmc.config.api.metadata.MetadataType;
+import org.quiltmc.config.api.serializer.Json5Serializer;
+import org.quiltmc.config.api.serializer.TomlSerializer;
+import org.quiltmc.config.api.values.TrackedValue;
+import org.quiltmc.config.api.values.ValueList;
+import org.quiltmc.config.api.values.ValueMap;
+import org.quiltmc.config.impl.CommentsImpl;
+import org.quiltmc.config.implementor_api.ConfigFactory;
+import org.quiltmc.config.reflective.input.TestValueConfig3;
+import org.quiltmc.config.reflective.input.TestValueConfig4;
+import org.quiltmc.config.reflective.input.TestValueListConfig;
+import org.quiltmc.config.reflective.input.TestValueMapConfig;
+import org.quiltmc.config.reflective.input.TestReflectiveConfig;
+import org.quiltmc.config.reflective.input.TestReflectiveConfig2;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Optional;
+
+@SuppressWarnings("deprecation")
+public class ConfigTest {
+	static ConfigEnvironment ENV;
+
+	static TrackedValue<String> TEST;
+	static TrackedValue<Integer> TEST_INTEGER;
+	static TrackedValue<Boolean> TEST_BOOLEAN;
+	static TrackedValue<String> TEST_STRING;
+	static TrackedValue<ValueList<Integer>> TEST_LIST;
+
+	@BeforeAll
+	public static void initializeConfigDir() throws IOException {
+		TestUtil.deleteTempDir();
+
+		ENV = new ConfigEnvironment(TestUtil.TEMP_DIR, TomlSerializer.INSTANCE, Json5Serializer.INSTANCE);
+	}
+
+	@AfterAll
+	public static void deleteConfigDir() throws IOException {
+		TestUtil.deleteTempDir();
+	}
+
+	@Test
+	public void testSerializer() {
+		Config config = Config.create(ENV, "wrapped", "testConfig6", builder -> {
+			builder.field(TrackedValue.create(0, "testInteger", creator -> {
+				creator.metadata(Comment.TYPE, comments -> comments.add("Comment one"));
+				creator.metadata(Comment.TYPE, comments -> comments.add("Comment two"));
+				creator.metadata(Comment.TYPE, comments -> comments.add("Comment three"));
+			}));
+			builder.section("super_awesome_section", section1 -> {
+				section1.metadata(Comment.TYPE, comments -> comments.add("This is a section comment!"));
+				section1.metadata(SerializedName.TYPE, name -> name.withName("super_duper_awesome_section"));
+				section1.field(TrackedValue.create(1, "before"));
+				section1.section("less_awesome_section", section2 -> {
+					section2.metadata(SerializedName.TYPE, name -> name.withName("much_less_awesome_section"));
+					section2.metadata(Comment.TYPE, comments -> comments.add("This is another section comment!"));
+					section2.section("regular_section", section3 -> {
+						section3.field(TrackedValue.create(0, "water"));
+						section3.field(TrackedValue.create(0, "earth"));
+						section3.field(TrackedValue.create(0, "fire", creator -> {
+							creator.metadata(Comment.TYPE, comments -> comments.add("This is a field comment!"));
+							creator.metadata(Comment.TYPE, comments -> comments.add("This is another field comment!"));
+
+						}));
+						section3.field(TrackedValue.create(0, "air"));
+					});
+					section2.field(TrackedValue.create("lemonade", "crunchy_ice"));
+				});
+				section1.field(TEST = TrackedValue.create("woot", "after"));
+			});
+			builder.field(TrackedValue.create(true, "testtt32"));
+			builder.field(TrackedValue.create(false, "testBoolean"));
+			builder.field(TrackedValue.create("blah", "testString"));
+			builder.field(TrackedValue.create(100, "a", "b", "c1", "d"));
+			builder.field(TrackedValue.create(1234, "a", "b", "c2"));
+			builder.field(TrackedValue.create(
+					ValueList.create(0, 1, 2, 3, 4), "testList1"
+			));
+			builder.field(TrackedValue.create(
+					ValueList.create(ValueMap.builder(ValueList.create("")).put("one", ValueList.create("")).build(),
+							ValueMap.builder(ValueList.create("")).put("one", ValueList.create("")).build(),
+							ValueMap.builder(ValueList.create("")).put("one", ValueList.create("")).build(),
+							ValueMap.builder(ValueList.create("")).put("one", ValueList.create("")).build()), "testList2"
+			));
+		});
+
+		TEST.setValue("This value was set programmatically!", true);
+	}
+
+	@Test
+	public void testValidation() {
+		Assertions.assertThrows(TrackedValueException.class, () -> Config.create(ENV, "wrapped", "testConfig1", builder -> builder.field(TrackedValue.create(new ArrayList<Integer>(), "boop"))));
+
+		Assertions.assertThrows(TrackedValueException.class, () -> Config.create(ENV, "wrapped", "testConfig2", builder -> builder.field(TrackedValue.create(ValueList.create(new ArrayList<Integer>()), "boop"))));
+	}
+
+	@Test
+	public void testValues() {
+		Config config = Config.create(ENV, "wrapped", "testConfig3", builder -> {
+			builder.field(TEST_INTEGER = TrackedValue.create(0, "testInteger"));
+			builder.field(TEST_BOOLEAN = TrackedValue.create(false, "testBoolean"));
+			builder.field(TEST_STRING  = TrackedValue.create("blah", "testString"));
+			builder.field(TEST_LIST = TrackedValue.create(
+					ValueList.create(0, 1, 2, 3, 4), "testList"
+			));
+			builder.section("testSection", section -> {
+				section.metadata(Comment.TYPE, comments -> comments.add("Section comment 1"));
+				section.metadata(Comment.TYPE, comments -> comments.add("Section comment 2"));
+				section.metadata(Comment.TYPE, comments -> comments.add("Section comment 3"));
+				section.field(TrackedValue.create("wooooh", "emote"));
+				section.field(TrackedValue.create("etrator", "perp"));
+			});
+			builder.callback(c -> System.out.println("We was updated!"));
+		});
+
+		TEST_STRING.registerCallback((value) ->
+				System.out.printf("Value '%s' updated: New value: '%s'%n", value.key(), value.value())
+		);
+
+		for (TrackedValue<?> value : config.values()) {
+			System.out.printf("\"%s\": %s%n", value.key(), value.value());
+		}
+
+		TEST_STRING.setValue("walalala", true);
+
+		System.out.println();
+
+		for (TrackedValue<?> value : config.values()) {
+			System.out.printf("\"%s\": %s%n", value.key(), value.value());
+		}
+	}
+
+	@Test
+	public void testMetadata() {
+		Config config = Config.create(ENV, "wrapped", "testConfig4", builder -> {
+			builder.field(TEST_INTEGER = TrackedValue.create(0, "testInteger", creator -> creator.metadata(Comment.TYPE, comments -> comments.add(
+					"Comment one",
+					"Comment two",
+					"Comment three"
+			))));
+			builder.field(TEST_BOOLEAN = TrackedValue.create(false, "testBoolean"));
+			builder.field(TEST_STRING  = TrackedValue.create("blah", "testString"));
+		});
+
+		for (TrackedValue<?> value : config.values()) {
+			System.out.printf("\"%s\": %s%n", value.key(), value.value());
+
+			for (String comment : value.metadata(Comment.TYPE)) {
+				System.out.printf("\t// %s%n", comment);
+			}
+		}
+	}
+
+	@Test
+	public void testFlags() {
+		Config config = Config.create(ENV, "wrapped", "testConfig5", builder -> {
+			builder.field(TEST_INTEGER = TrackedValue.create(0, "testInteger"));
+			builder.field(TEST_BOOLEAN = TrackedValue.create(false, "testBoolean"));
+			builder.field(TEST_STRING  = TrackedValue.create("blah", "testString"));
+		});
+
+		for (TrackedValue<?> value : config.values()) {
+			System.out.printf("\"%s\": %s%n", value.key(), value.value());
+
+			for (String comment : value.metadata(Comment.TYPE)) {
+				System.out.printf("\t// %s%n", comment);
+			}
+		}
+	}
+
+	@Test
+	public void testConstraints() {
+		Assertions.assertThrows(TrackedValueException.class, () -> Config.create(ENV, "wrapped", "testConfig6", builder -> {
+			builder.field(TEST_INTEGER = TrackedValue.create(0, "testInteger", creator -> {
+				// Should throw an exception since the default value is outside of the constraint range
+				creator.constraint(Constraint.range(5, 10));
+			}));
+			builder.field(TEST_BOOLEAN = TrackedValue.create(false, "testBoolean"));
+			builder.field(TEST_STRING  = TrackedValue.create("blah", "testString"));
+		}));
+
+		Assertions.assertThrows(TrackedValueException.class, () -> {
+			Config.create(ENV, "wrapped", "testConfig7", builder -> {
+				builder.field(TEST_INTEGER = TrackedValue.create(0, "testInteger", creator -> creator.constraint(Constraint.range(-10, 10))));
+				builder.field(TEST_BOOLEAN = TrackedValue.create(false, "testBoolean"));
+				builder.field(TEST_STRING  = TrackedValue.create("blah", "testString"));
+			});
+
+			TEST_INTEGER.setValue(1000, true);
+		});
+
+		Assertions.assertThrows(TrackedValueException.class, () -> {
+			Config.create(ENV, "wrapped", "testConfig8", builder -> {
+				builder.field(TEST_INTEGER = TrackedValue.create(0, "testInteger", creator -> creator.constraint(Constraint.range(-10, 10))));
+				builder.field(TEST_BOOLEAN = TrackedValue.create(false, "testBoolean"));
+				builder.field(TEST_STRING  = TrackedValue.create("blah", "test", creator -> creator.constraint(Constraint.matching("[a-zA-Z0-9]+:[a-zA-Z0-9]+"))));
+			});
+
+			TEST_INTEGER.setValue(1000, true);
+		});
+
+		Config.create(ENV, "wrapped", "testConfig9", builder -> {
+			builder.field(TEST_INTEGER = TrackedValue.create(0, "testInteger", creator -> creator.constraint(Constraint.range(-10, 10))));
+			builder.field(TEST_BOOLEAN = TrackedValue.create(false, "testBoolean"));
+			builder.field(TEST_STRING  = TrackedValue.create("test:id", "test", creator -> creator.constraint(Constraint.matching("[a-zA-Z0-9]+:[a-zA-Z0-9]+"))));
+		});
+	}
+
+	public void testWrappedConfigs(String id, String format) {
+		TestReflectiveConfig config = ConfigFactory.create(ENV, "wrapped", id, TestReflectiveConfig.class, builder -> builder.format(format));
+
+		for (TrackedValue<?> value : config.values()) {
+			System.out.printf("\"%s\": %s%n", value.key(), value.value());
+
+			for (String comment : value.metadata(Comment.TYPE)) {
+				System.out.printf("\t// %s%n", comment);
+			}
+		}
+
+		Assertions.assertThrows(ConfigCreationException.class, () -> ConfigFactory.create(ENV, "wrapped", "testConfig", TestReflectiveConfig2.class)).printStackTrace();
+
+		Assertions.assertThrows(ConfigFieldException.class, () -> ConfigFactory.create(ENV, "wrapped", "testConfig", TestValueConfig3.class)).printStackTrace();
+
+		Assertions.assertThrows(TrackedValueException.class, () -> ConfigFactory.create(ENV, "wrapped", "testConfig", TestValueConfig4.class)).printStackTrace();
+	}
+
+	@Test
+	public void testWrappedConfigs() {
+		testWrappedConfigs("testConfig10", "toml");
+		testWrappedConfigs("testConfig11", "json5");
+	}
+
+	@Test
+	public void testTomlConfigs() {
+		TestReflectiveConfig config = ConfigFactory.create(ENV, "wrapped", "testConfig12", TestReflectiveConfig.class, builder -> builder.format("toml"));
+
+		for (TrackedValue<?> value : config.values()) {
+			System.out.printf("\"%s\": %s%n", value.key(), value.value());
+
+			for (String comment : value.metadata(Comment.TYPE)) {
+				System.out.printf("\t// %s%n", comment);
+			}
+		}
+	}
+
+	@Test
+	public void testValueMapBehavior() {
+		TestValueMapConfig c = ConfigFactory.create(ENV, "wrapped", "testConfig13", TestValueMapConfig.class);
+
+		c.weights.value().put("" + c.weights.value().size(), c.weights.value().size());
+	}
+
+	@Test
+	public void testValueListBehavior() {
+		TestValueListConfig c = ConfigFactory.create(ENV, "wrapped", "testConfig14", TestValueListConfig.class);
+
+		c.strings.value().add(c.strings.value().size() + "");
+	}
+
+	@Test
+	public void testInferredMetadataType() {
+		MetadataType<Comments, Comment.Builder> TYPE = MetadataType.create(() -> Optional.of(new CommentsImpl(Collections.emptyList())), type -> {
+			if (type == String.class) {
+				return Optional.of(new CommentsImpl(Collections.singletonList("marinara")));
+			} else {
+				return Optional.of(new CommentsImpl(Collections.emptyList()));
+			}
+		}, Comment.Builder::new);
+
+		Config config = Config.create(ENV, "wrapped", "testConfig400", builder -> {
+			builder.field(TEST_INTEGER = TrackedValue.create(0, "testInteger", creator -> creator.metadata(TYPE, comments -> comments.add(
+					"Comment one",
+					"Comment two",
+					"Comment three"
+			))));
+			builder.field(TEST_BOOLEAN = TrackedValue.create(false, "testBoolean"));
+			builder.field(TEST_STRING  = TrackedValue.create("blah", "testString"));
+		});
+
+		for (TrackedValue<?> value : config.values()) {
+			for (String comment : value.metadata(TYPE)) {
+				System.out.printf("%s: %s%n", value.key(), comment);
+			}
+		}
+	}
+}

--- a/src/test/java/org/quiltmc/config/reflective/ReadWriteCycleTest.java
+++ b/src/test/java/org/quiltmc/config/reflective/ReadWriteCycleTest.java
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package org.quiltmc.config;
+package org.quiltmc.config.reflective;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.quiltmc.config.TestUtil;
 import org.quiltmc.config.api.Config;
 import org.quiltmc.config.api.metadata.MetadataType;
 import org.quiltmc.config.api.values.TrackedValue;
@@ -27,7 +28,7 @@ import org.quiltmc.config.api.values.ValueMap;
 import org.quiltmc.config.api.values.ValueTreeNode;
 import org.quiltmc.config.impl.util.ConfigsImpl;
 import org.quiltmc.config.implementor_api.ConfigFactory;
-import org.quiltmc.config.reflective.TestReflectiveConfig;
+import org.quiltmc.config.reflective.input.TestReflectiveConfig;
 
 import java.io.IOException;
 import java.util.Map;

--- a/src/test/java/org/quiltmc/config/reflective/TestSerializerEscaping.java
+++ b/src/test/java/org/quiltmc/config/reflective/TestSerializerEscaping.java
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
-package org.quiltmc.config;
+package org.quiltmc.config.reflective;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.quiltmc.config.TestUtil;
 import org.quiltmc.config.implementor_api.ConfigFactory;
-import org.quiltmc.config.reflective.TestEscapingConfig;
+import org.quiltmc.config.reflective.input.TestEscapingConfig;
 
 import java.io.IOException;
 import java.nio.file.Files;

--- a/src/test/java/org/quiltmc/config/reflective/input/TestEscapingConfig.java
+++ b/src/test/java/org/quiltmc/config/reflective/input/TestEscapingConfig.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.quiltmc.config.reflective;
+package org.quiltmc.config.reflective.input;
 
 import org.quiltmc.config.api.ReflectiveConfig;
 import org.quiltmc.config.api.annotations.SerializedName;

--- a/src/test/java/org/quiltmc/config/reflective/input/TestReflectiveConfig.java
+++ b/src/test/java/org/quiltmc/config/reflective/input/TestReflectiveConfig.java
@@ -14,42 +14,79 @@
  * limitations under the License.
  */
 
-package org.quiltmc.config.reflective;
+package org.quiltmc.config.reflective.input;
 
 import org.quiltmc.config.Vec3i;
+import org.quiltmc.config.api.Config;
 import org.quiltmc.config.api.ReflectiveConfig;
 import org.quiltmc.config.api.annotations.Comment;
-import org.quiltmc.config.api.annotations.FloatRange;
+import org.quiltmc.config.api.annotations.IntegerRange;
+import org.quiltmc.config.api.annotations.Matches;
+import org.quiltmc.config.api.annotations.Processor;
 import org.quiltmc.config.api.annotations.SerializedName;
 import org.quiltmc.config.api.values.TrackedValue;
 import org.quiltmc.config.api.values.ValueList;
 import org.quiltmc.config.api.values.ValueMap;
 
-public final class TestValueConfig3 extends ReflectiveConfig {
+/**
+ * A test config designed to use absolutely every single possible feature.
+ */
+@Processor("processConfig")
+public final class TestReflectiveConfig extends ReflectiveConfig {
 	@Comment({"Comment one", "Comment two"})
+	@SerializedName("george")
 	public final TrackedValue<Integer> a = this.value(0);
+
+	@Comment("Comment one")
+	@Comment("Comment two")
 	public final TrackedValue<Integer> b = this.value(1);
 	public final TrackedValue<Integer> c = this.value(2);
-	@FloatRange(min=0, max=10)
+
+	@IntegerRange(min=0, max=10)
 	public final TrackedValue<Integer> d = this.value(3);
+	@SerializedName("custom_serialized_name_vec")
 	public final TrackedValue<Vec3i> vec = this.value(new Vec3i(100, 200, 300));
+
+	@Matches("[a-zA-Z]+")
 	public final TrackedValue<String> whatever = this.value("Riesling");
+	@SerializedName("reallyAwesomeNested")
+	@Comment("comment!")
 	public final Nested nested1 = new Nested();
 	public final Nested nested3 = new Nested();
+
+	public final TrackedValue<ValueList<String>> enabled = this.list("");
+
+	@Processor("processField")
 	public final TrackedValue<ValueList<Vec3i>> vecs = this.list(new Vec3i(0, 0, 0),
 			new Vec3i(1, 2, 3),
 			new Vec3i(4, 5, 6),
 			new Vec3i(7, 8, 9)
 	);
 
-	@Comment("Test section comment")
+	@Comment("Test section comment 1")
+	@Comment("Test section comment 2")
+	@Comment("Test section comment 3")
+	@Comment("Test section comment 4")
 	public final Nested nested4 = new Nested();
+
+	public final TrackedValue<ValueMap<ValueList<String>>> key_binds = this.map(ValueList.create("")).build();
+
+	@IntegerRange(min=0, max=10)
+	public final TrackedValue<ValueList<Integer>> ints = this.list(0, 1, 2, 3, 4);
 
 	public final TrackedValue<ValueList<ValueMap<Integer>>> listOfNestedObjects = this.list(ValueMap.builder(0).build(),
 			ValueMap.builder(0).put("a", 1).put("b", 2).put("c", 3).put("d", 4).build(),
 			ValueMap.builder(0).put("a", 1).put("b", 2).put("c", 3).put("d", 4).build(),
 			ValueMap.builder(0).put("a", 1).put("b", 2).put("c", 3).put("d", 4).build()
 	);
+
+	public void processConfig(Config.Builder builder) {
+		System.out.println("Processing config!");
+	}
+
+	public void processField(TrackedValue.Builder<Vec3i> process) {
+		System.out.println("Processing field!");
+	}
 
 	public static final class Nested extends Section {
 		@SerializedName("custom_serialized_name_a")

--- a/src/test/java/org/quiltmc/config/reflective/input/TestReflectiveConfig2.java
+++ b/src/test/java/org/quiltmc/config/reflective/input/TestReflectiveConfig2.java
@@ -14,79 +14,31 @@
  * limitations under the License.
  */
 
-package org.quiltmc.config.reflective;
+package org.quiltmc.config.reflective.input;
 
-import org.quiltmc.config.Vec3i;
-import org.quiltmc.config.api.Config;
 import org.quiltmc.config.api.ReflectiveConfig;
 import org.quiltmc.config.api.annotations.Comment;
-import org.quiltmc.config.api.annotations.IntegerRange;
-import org.quiltmc.config.api.annotations.Matches;
-import org.quiltmc.config.api.annotations.Processor;
 import org.quiltmc.config.api.annotations.SerializedName;
 import org.quiltmc.config.api.values.TrackedValue;
 import org.quiltmc.config.api.values.ValueList;
 import org.quiltmc.config.api.values.ValueMap;
 
-/**
- * A test config designed to use absolutely every single possible feature.
- */
-@Processor("processConfig")
-public final class TestReflectiveConfig extends ReflectiveConfig {
+public final class TestReflectiveConfig2 extends ReflectiveConfig {
 	@Comment({"Comment one", "Comment two"})
-	@SerializedName("george")
 	public final TrackedValue<Integer> a = this.value(0);
-
-	@Comment("Comment one")
-	@Comment("Comment two")
 	public final TrackedValue<Integer> b = this.value(1);
 	public final TrackedValue<Integer> c = this.value(2);
-
-	@IntegerRange(min=0, max=10)
 	public final TrackedValue<Integer> d = this.value(3);
-	@SerializedName("custom_serialized_name_vec")
-	public final TrackedValue<Vec3i> vec = this.value(new Vec3i(100, 200, 300));
-
-	@Matches("[a-zA-Z]+")
-	public final TrackedValue<String> whatever = this.value("Riesling");
-	@SerializedName("reallyAwesomeNested")
-	@Comment("comment!")
+	public final TrackedValue<String> whatever = this.value(null);
 	public final Nested nested1 = new Nested();
 	public final Nested nested3 = new Nested();
-
-	public final TrackedValue<ValueList<String>> enabled = this.list("");
-
-	@Processor("processField")
-	public final TrackedValue<ValueList<Vec3i>> vecs = this.list(new Vec3i(0, 0, 0),
-			new Vec3i(1, 2, 3),
-			new Vec3i(4, 5, 6),
-			new Vec3i(7, 8, 9)
-	);
-
-	@Comment("Test section comment 1")
-	@Comment("Test section comment 2")
-	@Comment("Test section comment 3")
-	@Comment("Test section comment 4")
 	public final Nested nested4 = new Nested();
-
-	public final TrackedValue<ValueMap<ValueList<String>>> key_binds = this.map(ValueList.create("")).build();
-
-	@IntegerRange(min=0, max=10)
-	public final TrackedValue<ValueList<Integer>> ints = this.list(0, 1, 2, 3, 4);
 
 	public final TrackedValue<ValueList<ValueMap<Integer>>> listOfNestedObjects = this.list(ValueMap.builder(0).build(),
 			ValueMap.builder(0).put("a", 1).put("b", 2).put("c", 3).put("d", 4).build(),
 			ValueMap.builder(0).put("a", 1).put("b", 2).put("c", 3).put("d", 4).build(),
 			ValueMap.builder(0).put("a", 1).put("b", 2).put("c", 3).put("d", 4).build()
 	);
-
-	public void processConfig(Config.Builder builder) {
-		System.out.println("Processing config!");
-	}
-
-	public void processField(TrackedValue.Builder<Vec3i> process) {
-		System.out.println("Processing field!");
-	}
 
 	public static final class Nested extends Section {
 		@SerializedName("custom_serialized_name_a")

--- a/src/test/java/org/quiltmc/config/reflective/input/TestValueConfig3.java
+++ b/src/test/java/org/quiltmc/config/reflective/input/TestValueConfig3.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022-2024 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.config.reflective.input;
+
+import org.quiltmc.config.Vec3i;
+import org.quiltmc.config.api.ReflectiveConfig;
+import org.quiltmc.config.api.annotations.Comment;
+import org.quiltmc.config.api.annotations.FloatRange;
+import org.quiltmc.config.api.annotations.SerializedName;
+import org.quiltmc.config.api.values.TrackedValue;
+import org.quiltmc.config.api.values.ValueList;
+import org.quiltmc.config.api.values.ValueMap;
+
+public final class TestValueConfig3 extends ReflectiveConfig {
+	@Comment({"Comment one", "Comment two"})
+	public final TrackedValue<Integer> a = this.value(0);
+	public final TrackedValue<Integer> b = this.value(1);
+	public final TrackedValue<Integer> c = this.value(2);
+	@FloatRange(min=0, max=10)
+	public final TrackedValue<Integer> d = this.value(3);
+	public final TrackedValue<Vec3i> vec = this.value(new Vec3i(100, 200, 300));
+	public final TrackedValue<String> whatever = this.value("Riesling");
+	public final Nested nested1 = new Nested();
+	public final Nested nested3 = new Nested();
+	public final TrackedValue<ValueList<Vec3i>> vecs = this.list(new Vec3i(0, 0, 0),
+			new Vec3i(1, 2, 3),
+			new Vec3i(4, 5, 6),
+			new Vec3i(7, 8, 9)
+	);
+
+	@Comment("Test section comment")
+	public final Nested nested4 = new Nested();
+
+	public final TrackedValue<ValueList<ValueMap<Integer>>> listOfNestedObjects = this.list(ValueMap.builder(0).build(),
+			ValueMap.builder(0).put("a", 1).put("b", 2).put("c", 3).put("d", 4).build(),
+			ValueMap.builder(0).put("a", 1).put("b", 2).put("c", 3).put("d", 4).build(),
+			ValueMap.builder(0).put("a", 1).put("b", 2).put("c", 3).put("d", 4).build()
+	);
+
+	public static final class Nested extends Section {
+		@SerializedName("custom_serialized_name_a")
+		public final TrackedValue<Integer> a = this.value(0);
+		public final TrackedValue<Integer> b = this.value(1);
+		public final TrackedValue<Integer> c = this.value(2);
+		public final TrackedValue<Integer> d = this.value(3);
+	}
+}

--- a/src/test/java/org/quiltmc/config/reflective/input/TestValueConfig4.java
+++ b/src/test/java/org/quiltmc/config/reflective/input/TestValueConfig4.java
@@ -14,25 +14,49 @@
  * limitations under the License.
  */
 
-package org.quiltmc.config.reflective;
+package org.quiltmc.config.reflective.input;
 
+import org.quiltmc.config.Vec3i;
 import org.quiltmc.config.api.ReflectiveConfig;
 import org.quiltmc.config.api.annotations.Comment;
+import org.quiltmc.config.api.annotations.IntegerRange;
+import org.quiltmc.config.api.annotations.Matches;
 import org.quiltmc.config.api.annotations.SerializedName;
 import org.quiltmc.config.api.values.TrackedValue;
 import org.quiltmc.config.api.values.ValueList;
 import org.quiltmc.config.api.values.ValueMap;
 
-public final class TestReflectiveConfig2 extends ReflectiveConfig {
+public final class TestValueConfig4 extends ReflectiveConfig {
 	@Comment({"Comment one", "Comment two"})
 	public final TrackedValue<Integer> a = this.value(0);
+
+	@Comment("Comment one")
+	@Comment("Comment two")
 	public final TrackedValue<Integer> b = this.value(1);
 	public final TrackedValue<Integer> c = this.value(2);
+
+	@IntegerRange(min=0, max=10)
 	public final TrackedValue<Integer> d = this.value(3);
-	public final TrackedValue<String> whatever = this.value(null);
+	public final TrackedValue<Vec3i> vec = this.value(new Vec3i(100, 200, 300));
+
+	@Matches("[a-zA-Z]+")
+	public final TrackedValue<String> whatever = this.value("01234");
 	public final Nested nested1 = new Nested();
 	public final Nested nested3 = new Nested();
+	public final TrackedValue<ValueList<Vec3i>> vecs = this.list(new Vec3i(0, 0, 0),
+			new Vec3i(1, 2, 3),
+			new Vec3i(4, 5, 6),
+			new Vec3i(7, 8, 9)
+	);
+
+	@Comment("Test section comment 1")
+	@Comment("Test section comment 2")
+	@Comment("Test section comment 3")
+	@Comment("Test section comment 4")
 	public final Nested nested4 = new Nested();
+
+	@IntegerRange(min=0, max=10)
+	public final TrackedValue<ValueList<Integer>> ints = this.list(0, 1, 2, 3, 4);
 
 	public final TrackedValue<ValueList<ValueMap<Integer>>> listOfNestedObjects = this.list(ValueMap.builder(0).build(),
 			ValueMap.builder(0).put("a", 1).put("b", 2).put("c", 3).put("d", 4).build(),

--- a/src/test/java/org/quiltmc/config/reflective/input/TestValueListConfig.java
+++ b/src/test/java/org/quiltmc/config/reflective/input/TestValueListConfig.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022-2024 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.config.reflective.input;
+
+import org.quiltmc.config.api.ReflectiveConfig;
+import org.quiltmc.config.api.values.TrackedValue;
+import org.quiltmc.config.api.values.ValueList;
+
+public class TestValueListConfig extends ReflectiveConfig {
+	public final TrackedValue<String> test = this.value("watermark");
+	public final TrackedValue<Integer> thingy = this.value(1009);
+	public final TrackedValue<ValueList<String>> strings = this.list("");
+}

--- a/src/test/java/org/quiltmc/config/reflective/input/TestValueMapConfig.java
+++ b/src/test/java/org/quiltmc/config/reflective/input/TestValueMapConfig.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022-2024 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.config.reflective.input;
+
+import org.quiltmc.config.api.ReflectiveConfig;
+import org.quiltmc.config.api.values.TrackedValue;
+import org.quiltmc.config.api.values.ValueMap;
+
+public class TestValueMapConfig extends ReflectiveConfig {
+	public final TrackedValue<Integer> version = this.value(100);
+	public final TrackedValue<String> flavor = this.value("lemon");
+	public final TrackedValue<ValueMap<Integer>> weights = this.map(0).build();
+}


### PR DESCRIPTION
note that I haven't copied over new tests from the reflectiveconfig era. these tests mostly exist to confirm that the wrapped config impl still works for legacy users

depends on #22 before being merged