### PR TITLE
`@ConfigIgnored` annotation

### DIFF
--- a/src/main/java/org/quiltmc/config/api/annotations/ConfigIgnored.java
+++ b/src/main/java/org/quiltmc/config/api/annotations/ConfigIgnored.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.config.api.annotations;
 
 import java.lang.annotation.ElementType;

--- a/src/main/java/org/quiltmc/config/api/annotations/ConfigIgnored.java
+++ b/src/main/java/org/quiltmc/config/api/annotations/ConfigIgnored.java
@@ -1,0 +1,14 @@
+package org.quiltmc.config.api.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks this field as ignored by the config builder, meaning that it will not be treated as a config value and serialized.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface ConfigIgnored {
+}

--- a/src/main/java/org/quiltmc/config/impl/builders/ReflectiveConfigCreator.java
+++ b/src/main/java/org/quiltmc/config/impl/builders/ReflectiveConfigCreator.java
@@ -18,6 +18,7 @@ package org.quiltmc.config.impl.builders;
 
 import org.quiltmc.config.api.Config;
 import org.quiltmc.config.api.ReflectiveConfig;
+import org.quiltmc.config.api.annotations.ConfigIgnored;
 import org.quiltmc.config.api.annotations.Processor;
 import org.quiltmc.config.api.values.TrackedValue;
 import org.quiltmc.config.impl.ConfigFieldAnnotationProcessors;
@@ -41,7 +42,7 @@ public class ReflectiveConfigCreator<C> implements Config.Creator {
 
 	@SuppressWarnings({"unchecked", "rawtypes"})
 	private void createField(Config.SectionBuilder builder, Object object, Field field) throws IllegalAccessException {
-		if (!Modifier.isStatic(field.getModifiers()) && !Modifier.isTransient(field.getModifiers())) {
+		if (!Modifier.isStatic(field.getModifiers()) && !Modifier.isTransient(field.getModifiers()) && !field.isAnnotationPresent(ConfigIgnored.class)) {
 			if (!Modifier.isFinal(field.getModifiers())) {
 				throw new ConfigFieldException("Field '" + field.getType().getName() + ':' + field.getName() + "' is not final!");
 			}

--- a/src/test/java/org/quiltmc/config/old_wrapped/ConfigTest.java
+++ b/src/test/java/org/quiltmc/config/old_wrapped/ConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/quiltmc/config/old_wrapped/input/TestValueConfig3.java
+++ b/src/test/java/org/quiltmc/config/old_wrapped/input/TestValueConfig3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/quiltmc/config/old_wrapped/input/TestValueConfig4.java
+++ b/src/test/java/org/quiltmc/config/old_wrapped/input/TestValueConfig4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/quiltmc/config/old_wrapped/input/TestValueListConfig.java
+++ b/src/test/java/org/quiltmc/config/old_wrapped/input/TestValueListConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/quiltmc/config/old_wrapped/input/TestValueMapConfig.java
+++ b/src/test/java/org/quiltmc/config/old_wrapped/input/TestValueMapConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/quiltmc/config/old_wrapped/input/TestWrappedConfig.java
+++ b/src/test/java/org/quiltmc/config/old_wrapped/input/TestWrappedConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/quiltmc/config/old_wrapped/input/TestWrappedConfig2.java
+++ b/src/test/java/org/quiltmc/config/old_wrapped/input/TestWrappedConfig2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 QuiltMC
+ * Copyright 2022-2024 QuiltMC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/quiltmc/config/reflective/input/TestReflectiveConfig.java
+++ b/src/test/java/org/quiltmc/config/reflective/input/TestReflectiveConfig.java
@@ -20,6 +20,7 @@ import org.quiltmc.config.Vec3i;
 import org.quiltmc.config.api.Config;
 import org.quiltmc.config.api.ReflectiveConfig;
 import org.quiltmc.config.api.annotations.Comment;
+import org.quiltmc.config.api.annotations.ConfigIgnored;
 import org.quiltmc.config.api.annotations.IntegerRange;
 import org.quiltmc.config.api.annotations.Matches;
 import org.quiltmc.config.api.annotations.Processor;
@@ -31,11 +32,17 @@ import org.quiltmc.config.api.values.ValueMap;
 /**
  * A test config designed to use absolutely every single possible feature.
  */
+@SuppressWarnings("unused")
 @Processor("processConfig")
 public final class TestReflectiveConfig extends ReflectiveConfig {
 	@Comment({"Comment one", "Comment two"})
 	@SerializedName("george")
 	public final TrackedValue<Integer> a = this.value(0);
+
+	// this value would throw an exception for being non-final if it was considered by the config
+	// if tests pass, this annotation is working!
+	@ConfigIgnored
+	public Integer gaming = 4897;
 
 	@Comment("Comment one")
 	@Comment("Comment two")


### PR DESCRIPTION
marks a field as ignored by the config, allowing you to put other fields in your config classes