### PR TITLE
Implement GUI annotations and metadata

### DIFF
--- a/src/main/java/org/quiltmc/config/api/annotations/ChangeWarning.java
+++ b/src/main/java/org/quiltmc/config/api/annotations/ChangeWarning.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
 import java.util.Optional;
 
 /**
- * Used to tell config screen libraries that a warning should be displayed before applying changes. Can be applied to configs, sections and properties.
+ * Used to tell config screen libraries that a warning should be displayed before applying changes. Can be applied to configs, sections and fields.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.TYPE})

--- a/src/main/java/org/quiltmc/config/api/annotations/ChangeWarning.java
+++ b/src/main/java/org/quiltmc/config/api/annotations/ChangeWarning.java
@@ -46,7 +46,6 @@ public @interface ChangeWarning {
 	 */
 	String customMessage() default "";
 
-
 	final class Builder implements MetadataType.Builder<org.quiltmc.config.api.metadata.ChangeWarning> {
 		private String message;
 		private org.quiltmc.config.api.metadata.ChangeWarning.Type type;

--- a/src/main/java/org/quiltmc/config/api/annotations/ChangeWarning.java
+++ b/src/main/java/org/quiltmc/config/api/annotations/ChangeWarning.java
@@ -1,0 +1,66 @@
+package org.quiltmc.config.api.annotations;
+
+import org.quiltmc.config.api.Config;
+import org.quiltmc.config.api.metadata.MetadataType;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Optional;
+
+/**
+ * Used to tell config screen libraries that a warning should be displayed before applying changes
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.TYPE})
+public @interface ChangeWarning {
+	/**
+	 * A {@link MetadataType} to supply to {@link Config.Builder#metadata}
+	 */
+	MetadataType<org.quiltmc.config.api.metadata.ChangeWarning, ChangeWarning.Builder> TYPE = MetadataType.create(Optional::empty, ChangeWarning.Builder::new);
+
+	/**
+	 * The {@link org.quiltmc.config.api.metadata.ChangeWarning.Type ChangeWarning.Type} of the change warning
+	 */
+	org.quiltmc.config.api.metadata.ChangeWarning.Type value();
+
+	/**
+	 * The message to display if the type is {@link org.quiltmc.config.api.metadata.ChangeWarning.Type#Custom ChangeWarning.Type.Custom}, or the translation key if it is {@link org.quiltmc.config.api.metadata.ChangeWarning.Type#CustomTranslatable ChangeWarning.Type.CustomTranslatable}
+	 */
+	String customMessage() default "";
+
+
+	final class Builder implements MetadataType.Builder<org.quiltmc.config.api.metadata.ChangeWarning> {
+		private String message;
+		private org.quiltmc.config.api.metadata.ChangeWarning.Type type;
+
+		public Builder() {
+		}
+
+		/**
+		 * Utility for updating the type and the message
+		 */
+		public void setMessage(String message) {
+			this.setType(org.quiltmc.config.api.metadata.ChangeWarning.Type.Custom);
+			this.message = message;
+		}
+
+		public void setType(org.quiltmc.config.api.metadata.ChangeWarning.Type type) {
+			this.type = type;
+		}
+
+		/**
+		 * Utility for updating the type and the message
+		 */
+		public void setTranslatableMessage(String translationKey) {
+			this.setType(org.quiltmc.config.api.metadata.ChangeWarning.Type.CustomTranslatable);
+			this.setMessage(translationKey);
+		}
+
+		@Override
+		public org.quiltmc.config.api.metadata.ChangeWarning build() {
+			return new org.quiltmc.config.api.metadata.ChangeWarning(this.message, this.type);
+		}
+	}
+}

--- a/src/main/java/org/quiltmc/config/api/annotations/ChangeWarning.java
+++ b/src/main/java/org/quiltmc/config/api/annotations/ChangeWarning.java
@@ -18,7 +18,7 @@ public @interface ChangeWarning {
 	/**
 	 * A {@link MetadataType} to supply to {@link Config.Builder#metadata}
 	 */
-	MetadataType<org.quiltmc.config.api.metadata.ChangeWarning, ChangeWarning.Builder> TYPE = MetadataType.create(Optional::empty, ChangeWarning.Builder::new);
+	MetadataType<org.quiltmc.config.api.metadata.ChangeWarning, ChangeWarning.Builder> TYPE = MetadataType.create(Optional::empty, ChangeWarning.Builder::new, true);
 
 	/**
 	 * The {@link org.quiltmc.config.api.metadata.ChangeWarning.Type ChangeWarning.Type} of the change warning

--- a/src/main/java/org/quiltmc/config/api/annotations/ChangeWarning.java
+++ b/src/main/java/org/quiltmc/config/api/annotations/ChangeWarning.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
 import java.util.Optional;
 
 /**
- * Used to tell config screen libraries that a warning should be displayed before applying changes
+ * Used to tell config screen libraries that a warning should be displayed before applying changes. Can be applied to configs, sections and properties.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.TYPE})
@@ -42,7 +42,7 @@ public @interface ChangeWarning {
 	org.quiltmc.config.api.metadata.ChangeWarning.Type value();
 
 	/**
-	 * The message to display if the type is {@link org.quiltmc.config.api.metadata.ChangeWarning.Type#Custom ChangeWarning.Type.Custom}, or the translation key if it is {@link org.quiltmc.config.api.metadata.ChangeWarning.Type#CustomTranslatable ChangeWarning.Type.CustomTranslatable}
+	 * The message to display if the type is {@link org.quiltmc.config.api.metadata.ChangeWarning.Type#Custom ChangeWarning.Type.Custom}. In that case, Metadata processors (like config screens) may define translation keys that take precedence, else the translation key if it is {@link org.quiltmc.config.api.metadata.ChangeWarning.Type#CustomTranslatable ChangeWarning.Type.CustomTranslatable}.
 	 */
 	String customMessage() default "";
 

--- a/src/main/java/org/quiltmc/config/api/annotations/ChangeWarning.java
+++ b/src/main/java/org/quiltmc/config/api/annotations/ChangeWarning.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.config.api.annotations;
 
 import org.quiltmc.config.api.Config;

--- a/src/main/java/org/quiltmc/config/api/annotations/DisplayName.java
+++ b/src/main/java/org/quiltmc/config/api/annotations/DisplayName.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
 import java.util.Optional;
 
 /**
- * Used to tell config screen libraries what name should be used for the annotated element when displaying it. Can be applied to configs, sections and properties.
+ * Used to tell config screen libraries what name should be used for the annotated element when displaying it. Can be applied to configs, sections and fields.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.TYPE})

--- a/src/main/java/org/quiltmc/config/api/annotations/DisplayName.java
+++ b/src/main/java/org/quiltmc/config/api/annotations/DisplayName.java
@@ -1,0 +1,56 @@
+package org.quiltmc.config.api.annotations;
+
+import org.quiltmc.config.api.Config;
+import org.quiltmc.config.api.metadata.MetadataType;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Optional;
+
+/**
+ * Used to tell config screen libraries what name should be used for the annotated element when displaying it
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.TYPE})
+public @interface DisplayName {
+	/**
+	 * A {@link MetadataType} to supply to {@link Config.Builder#metadata}
+	 */
+	MetadataType<org.quiltmc.config.api.metadata.DisplayName, DisplayName.Builder> TYPE = MetadataType.create(
+		Optional::empty,
+		DisplayName.Builder::new
+	);
+
+	/**
+	 * The name for the config screen to use if {@link #translatable} is false. A translation key pointing to the name to be used otherwise
+	 */
+	String value();
+
+	/**
+	 * If true, {@link #value()} contains a translation key
+	 */
+	boolean translatable() default false;
+
+	final class Builder implements MetadataType.Builder<org.quiltmc.config.api.metadata.DisplayName> {
+		private String name;
+		private boolean translatable;
+
+		public Builder() {
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public void setTranslatable(boolean translatable) {
+			this.translatable = translatable;
+		}
+
+		@Override
+		public org.quiltmc.config.api.metadata.DisplayName build() {
+			return new org.quiltmc.config.api.metadata.DisplayName(this.name, this.translatable);
+		}
+	}
+}

--- a/src/main/java/org/quiltmc/config/api/annotations/DisplayName.java
+++ b/src/main/java/org/quiltmc/config/api/annotations/DisplayName.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.config.api.annotations;
 
 import org.quiltmc.config.api.Config;

--- a/src/main/java/org/quiltmc/config/api/annotations/DisplayName.java
+++ b/src/main/java/org/quiltmc/config/api/annotations/DisplayName.java
@@ -35,8 +35,8 @@ public @interface DisplayName {
 	 * A {@link MetadataType} to supply to {@link Config.Builder#metadata}
 	 */
 	MetadataType<org.quiltmc.config.api.metadata.DisplayName, DisplayName.Builder> TYPE = MetadataType.create(
-		Optional::empty,
-		DisplayName.Builder::new
+			Optional::empty,
+			DisplayName.Builder::new
 	);
 
 	/**

--- a/src/main/java/org/quiltmc/config/api/annotations/DisplayName.java
+++ b/src/main/java/org/quiltmc/config/api/annotations/DisplayName.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
 import java.util.Optional;
 
 /**
- * Used to tell config screen libraries what name should be used for the annotated element when displaying it
+ * Used to tell config screen libraries what name should be used for the annotated element when displaying it. Can be applied to configs, sections and properties.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.TYPE})
@@ -40,7 +40,7 @@ public @interface DisplayName {
 	);
 
 	/**
-	 * The name for the config screen to use if {@link #translatable} is false. A translation key pointing to the name to be used otherwise
+	 * The name for the config screen to use if {@link #translatable} is false. A translation key pointing to the name to be used otherwise. Metadata processors (like config screens) may define generated translation keys taking precedence if it isn't translatable.
 	 */
 	String value();
 

--- a/src/main/java/org/quiltmc/config/api/annotations/DisplayNameConvention.java
+++ b/src/main/java/org/quiltmc/config/api/annotations/DisplayNameConvention.java
@@ -54,7 +54,7 @@ public @interface DisplayNameConvention {
 		private NamingScheme scheme;
 
 		public Builder() {
-			scheme = NamingSchemes.PASSTHROUGH;
+			this.scheme = NamingSchemes.PASSTHROUGH;
 		}
 
 		public void set(NamingScheme scheme) {
@@ -63,7 +63,7 @@ public @interface DisplayNameConvention {
 
 		@Override
 		public NamingScheme build() {
-			return scheme;
+			return this.scheme;
 		}
 	}
 }

--- a/src/main/java/org/quiltmc/config/api/annotations/DisplayNameConvention.java
+++ b/src/main/java/org/quiltmc/config/api/annotations/DisplayNameConvention.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.config.api.annotations;
+
+import org.quiltmc.config.api.Config;
+import org.quiltmc.config.api.metadata.MetadataType;
+import org.quiltmc.config.api.metadata.NamingScheme;
+import org.quiltmc.config.api.metadata.NamingSchemes;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Optional;
+
+/**
+ * Used to tell config screen libraries how properties should be formatted when displaying them. Can be applied to configs, sections and properties. {@link DisplayName} must always take priority.
+ * @see org.quiltmc.config.api.annotations.DisplayName
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.TYPE})
+public @interface DisplayNameConvention {
+	/**
+	 * A {@link MetadataType} to supply to {@link Config.Builder#metadata}
+	 */
+	MetadataType<NamingScheme, DisplayNameConvention.Builder> TYPE = MetadataType.create(Optional::empty, DisplayNameConvention.Builder::new, true);
+
+	/**
+	 * One of the included {@link NamingSchemes}. {@link DisplayNameConvention#custom()} takes priority when not empty
+	 * @see NamingSchemes
+	 */
+	NamingSchemes value() default NamingSchemes.PASSTHROUGH;
+
+	/**
+	 * A fully qualified name of a class implementing the {@link NamingScheme}. Ignored when empty, takes precedence over {@link DisplayNameConvention#value()} otherwise.
+	 */
+	String custom() default "";
+
+	final class Builder implements MetadataType.Builder<NamingScheme> {
+		private NamingScheme scheme;
+
+		public Builder() {
+			scheme = NamingSchemes.PASSTHROUGH;
+		}
+
+		public void set(NamingScheme scheme) {
+			this.scheme = scheme;
+		}
+
+		@Override
+		public NamingScheme build() {
+			return scheme;
+		}
+	}
+}

--- a/src/main/java/org/quiltmc/config/api/annotations/DisplayNameConvention.java
+++ b/src/main/java/org/quiltmc/config/api/annotations/DisplayNameConvention.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
 import java.util.Optional;
 
 /**
- * Used to tell config screen libraries how properties should be formatted when displaying them. Can be applied to configs, sections and properties. {@link DisplayName} must always take priority.
+ * Used to tell config screen libraries how properties should be formatted when displaying them. Metadata processors (like config screens) may define generated translation keys taking precedence. Can be applied to configs, sections and properties. {@link DisplayName} must always take priority.
  * @see org.quiltmc.config.api.annotations.DisplayName
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/org/quiltmc/config/api/metadata/ChangeWarning.java
+++ b/src/main/java/org/quiltmc/config/api/metadata/ChangeWarning.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.quiltmc.config.api.metadata;
 
 import java.util.Objects;

--- a/src/main/java/org/quiltmc/config/api/metadata/ChangeWarning.java
+++ b/src/main/java/org/quiltmc/config/api/metadata/ChangeWarning.java
@@ -1,0 +1,61 @@
+package org.quiltmc.config.api.metadata;
+
+import java.util.Objects;
+
+public class ChangeWarning {
+	private final String customMessage;
+	private final Type type;
+
+	public ChangeWarning(String customMessage, Type type) {
+		this.customMessage = customMessage;
+		this.type = type;
+	}
+
+	public String getCustomMessage() {
+		return customMessage;
+	}
+
+	public Type getType() {
+		return type;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		ChangeWarning that = (ChangeWarning) o;
+		return Objects.equals(customMessage, that.customMessage) && type == that.type;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(customMessage, type);
+	}
+
+	public enum Type {
+		/**
+		 * indicates that the changed setting requires a restart to apply
+		 */
+		RequiresRestart,
+		/**
+		 * indicates that stuff may or will go wrong, and that that is intentional
+		 */
+		Unsafe,
+		/**
+		 * indicates that stuff may or will go wrong, because the setting is not mature enough
+		 */
+		Experimental,
+		/**
+		 * the message parameter contains the raw message to be displayed
+		 */
+		CustomTranslatable,
+		/**
+		 * the message parameter contains the translation key to be displayed
+		 */
+		Custom
+	}
+}

--- a/src/main/java/org/quiltmc/config/api/metadata/ChangeWarning.java
+++ b/src/main/java/org/quiltmc/config/api/metadata/ChangeWarning.java
@@ -28,11 +28,11 @@ public class ChangeWarning {
 	}
 
 	public String getCustomMessage() {
-		return customMessage;
+		return this.customMessage;
 	}
 
 	public Type getType() {
-		return type;
+		return this.type;
 	}
 
 	@Override
@@ -40,16 +40,18 @@ public class ChangeWarning {
 		if (this == o) {
 			return true;
 		}
+
 		if (o == null || getClass() != o.getClass()) {
 			return false;
 		}
+
 		ChangeWarning that = (ChangeWarning) o;
-		return Objects.equals(customMessage, that.customMessage) && type == that.type;
+		return Objects.equals(this.customMessage, that.customMessage) && this.type == that.type;
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(customMessage, type);
+		return Objects.hash(this.customMessage, this.type);
 	}
 
 	public enum Type {

--- a/src/main/java/org/quiltmc/config/api/metadata/DisplayName.java
+++ b/src/main/java/org/quiltmc/config/api/metadata/DisplayName.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023-2024 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.config.api.metadata;
+
+import java.security.InvalidParameterException;
+import java.util.Objects;
+
+public class DisplayName {
+	private final String name;
+	private final boolean translatable;
+
+	public DisplayName(String name, boolean translatable) {
+		if (name == null || name.isEmpty()) {
+			throw new InvalidParameterException("Cannot set serialized name to an empty value!");
+		}
+
+		this.translatable = translatable;
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public boolean isTranslatable() {
+		return translatable;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		DisplayName that = (DisplayName) o;
+		return translatable == that.translatable && Objects.equals(name, that.name);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(name, translatable);
+	}
+}

--- a/src/main/java/org/quiltmc/config/api/metadata/DisplayName.java
+++ b/src/main/java/org/quiltmc/config/api/metadata/DisplayName.java
@@ -33,11 +33,11 @@ public class DisplayName {
 	}
 
 	public String getName() {
-		return name;
+		return this.name;
 	}
 
 	public boolean isTranslatable() {
-		return translatable;
+		return this.translatable;
 	}
 
 	@Override
@@ -45,15 +45,17 @@ public class DisplayName {
 		if (this == o) {
 			return true;
 		}
+
 		if (o == null || getClass() != o.getClass()) {
 			return false;
 		}
+
 		DisplayName that = (DisplayName) o;
-		return translatable == that.translatable && Objects.equals(name, that.name);
+		return this.translatable == that.translatable && Objects.equals(this.name, that.name);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(name, translatable);
+		return Objects.hash(this.name, this.translatable);
 	}
 }

--- a/src/main/java/org/quiltmc/config/impl/ConfigFieldAnnotationProcessors.java
+++ b/src/main/java/org/quiltmc/config/impl/ConfigFieldAnnotationProcessors.java
@@ -20,6 +20,7 @@ import org.quiltmc.config.api.Constraint;
 import org.quiltmc.config.api.annotations.Alias;
 import org.quiltmc.config.api.annotations.Comment;
 import org.quiltmc.config.api.annotations.ConfigFieldAnnotationProcessor;
+import org.quiltmc.config.api.annotations.DisplayName;
 import org.quiltmc.config.api.annotations.FloatRange;
 import org.quiltmc.config.api.annotations.IntegerRange;
 import org.quiltmc.config.api.annotations.Matches;
@@ -51,6 +52,7 @@ public final class ConfigFieldAnnotationProcessors {
 		register(Matches.class, new MatchesProcessor());
 		register(SerializedName.class, new SerialNameProcessor());
 		register(SerializedNameConvention.class, new SerializedNameConventionProcessor());
+		register(DisplayName.class, new DisplayNameProcessor());
 	}
 
 	public static <T extends Annotation> void register(Class<T> annotationClass, ConfigFieldAnnotationProcessor<T> processor) {
@@ -101,6 +103,16 @@ public final class ConfigFieldAnnotationProcessors {
 		public void process(SerializedNameConvention annotation, MetadataContainerBuilder<?> builder) {
 			builder.metadata(SerializedNameConvention.TYPE, nameConventionBuilder -> nameConventionBuilder.set(
 					this.namingSchemeHelper.getNamingScheme(annotation, ConfigFieldException::new)));
+		}
+	}
+
+	private static final class DisplayNameProcessor implements ConfigFieldAnnotationProcessor<DisplayName> {
+		@Override
+		public void process(DisplayName name, MetadataContainerBuilder<?> builder) {
+			builder.metadata(DisplayName.TYPE, nameBuilder -> {
+				nameBuilder.setName(name.value());
+				nameBuilder.setTranslatable(name.translatable());
+			});
 		}
 	}
 

--- a/src/main/java/org/quiltmc/config/impl/ConfigFieldAnnotationProcessors.java
+++ b/src/main/java/org/quiltmc/config/impl/ConfigFieldAnnotationProcessors.java
@@ -17,16 +17,7 @@
 package org.quiltmc.config.impl;
 
 import org.quiltmc.config.api.Constraint;
-import org.quiltmc.config.api.annotations.Alias;
-import org.quiltmc.config.api.annotations.Comment;
-import org.quiltmc.config.api.annotations.ConfigFieldAnnotationProcessor;
-import org.quiltmc.config.api.annotations.DisplayName;
-import org.quiltmc.config.api.annotations.DisplayNameConvention;
-import org.quiltmc.config.api.annotations.FloatRange;
-import org.quiltmc.config.api.annotations.IntegerRange;
-import org.quiltmc.config.api.annotations.Matches;
-import org.quiltmc.config.api.annotations.SerializedName;
-import org.quiltmc.config.api.annotations.SerializedNameConvention;
+import org.quiltmc.config.api.annotations.*;
 import org.quiltmc.config.api.exceptions.ConfigFieldException;
 import org.quiltmc.config.api.metadata.MetadataContainerBuilder;
 import org.quiltmc.config.api.values.CompoundConfigValue;
@@ -55,6 +46,7 @@ public final class ConfigFieldAnnotationProcessors {
 		register(SerializedNameConvention.class, new SerializedNameConventionProcessor());
 		register(DisplayName.class, new DisplayNameProcessor());
 		register(DisplayNameConvention.class, new DisplayNameConventionProcessor());
+		register(ChangeWarning.class, new ChangeWarningProcessor());
 	}
 
 	public static <T extends Annotation> void register(Class<T> annotationClass, ConfigFieldAnnotationProcessor<T> processor) {
@@ -125,6 +117,17 @@ public final class ConfigFieldAnnotationProcessors {
 		public void process(DisplayNameConvention annotation, MetadataContainerBuilder<?> builder) {
 			builder.metadata(DisplayNameConvention.TYPE, nameConventionBuilder -> nameConventionBuilder.set(
 				namingSchemeHelper.getNamingScheme(annotation, ConfigFieldException::new)));
+		}
+	}
+
+	private static final class ChangeWarningProcessor implements ConfigFieldAnnotationProcessor<ChangeWarning> {
+		@Override
+		public void process(ChangeWarning name, MetadataContainerBuilder<?> builder) {
+			builder.metadata(ChangeWarning.TYPE, nameBuilder -> {
+				// Order matters because setMessage sets the type
+				nameBuilder.setMessage(name.customMessage());
+				nameBuilder.setType(name.value());
+			});
 		}
 	}
 

--- a/src/main/java/org/quiltmc/config/impl/ConfigFieldAnnotationProcessors.java
+++ b/src/main/java/org/quiltmc/config/impl/ConfigFieldAnnotationProcessors.java
@@ -21,6 +21,7 @@ import org.quiltmc.config.api.annotations.Alias;
 import org.quiltmc.config.api.annotations.Comment;
 import org.quiltmc.config.api.annotations.ConfigFieldAnnotationProcessor;
 import org.quiltmc.config.api.annotations.DisplayName;
+import org.quiltmc.config.api.annotations.DisplayNameConvention;
 import org.quiltmc.config.api.annotations.FloatRange;
 import org.quiltmc.config.api.annotations.IntegerRange;
 import org.quiltmc.config.api.annotations.Matches;
@@ -53,6 +54,7 @@ public final class ConfigFieldAnnotationProcessors {
 		register(SerializedName.class, new SerialNameProcessor());
 		register(SerializedNameConvention.class, new SerializedNameConventionProcessor());
 		register(DisplayName.class, new DisplayNameProcessor());
+		register(DisplayNameConvention.class, new DisplayNameConventionProcessor());
 	}
 
 	public static <T extends Annotation> void register(Class<T> annotationClass, ConfigFieldAnnotationProcessor<T> processor) {
@@ -113,6 +115,16 @@ public final class ConfigFieldAnnotationProcessors {
 				nameBuilder.setName(name.value());
 				nameBuilder.setTranslatable(name.translatable());
 			});
+		}
+	}
+
+	private static final class DisplayNameConventionProcessor implements ConfigFieldAnnotationProcessor<DisplayNameConvention> {
+		private final NamingSchemeHelper namingSchemeHelper = new NamingSchemeHelper();
+
+		@Override
+		public void process(DisplayNameConvention annotation, MetadataContainerBuilder<?> builder) {
+			builder.metadata(DisplayNameConvention.TYPE, nameConventionBuilder -> nameConventionBuilder.set(
+				namingSchemeHelper.getNamingScheme(annotation, ConfigFieldException::new)));
 		}
 	}
 

--- a/src/main/java/org/quiltmc/config/impl/ConfigFieldAnnotationProcessors.java
+++ b/src/main/java/org/quiltmc/config/impl/ConfigFieldAnnotationProcessors.java
@@ -17,7 +17,17 @@
 package org.quiltmc.config.impl;
 
 import org.quiltmc.config.api.Constraint;
-import org.quiltmc.config.api.annotations.*;
+import org.quiltmc.config.api.annotations.Alias;
+import org.quiltmc.config.api.annotations.ChangeWarning;
+import org.quiltmc.config.api.annotations.Comment;
+import org.quiltmc.config.api.annotations.ConfigFieldAnnotationProcessor;
+import org.quiltmc.config.api.annotations.DisplayName;
+import org.quiltmc.config.api.annotations.DisplayNameConvention;
+import org.quiltmc.config.api.annotations.FloatRange;
+import org.quiltmc.config.api.annotations.IntegerRange;
+import org.quiltmc.config.api.annotations.Matches;
+import org.quiltmc.config.api.annotations.SerializedName;
+import org.quiltmc.config.api.annotations.SerializedNameConvention;
 import org.quiltmc.config.api.exceptions.ConfigFieldException;
 import org.quiltmc.config.api.metadata.MetadataContainerBuilder;
 import org.quiltmc.config.api.values.CompoundConfigValue;
@@ -116,7 +126,7 @@ public final class ConfigFieldAnnotationProcessors {
 		@Override
 		public void process(DisplayNameConvention annotation, MetadataContainerBuilder<?> builder) {
 			builder.metadata(DisplayNameConvention.TYPE, nameConventionBuilder -> nameConventionBuilder.set(
-				namingSchemeHelper.getNamingScheme(annotation, ConfigFieldException::new)));
+					this.namingSchemeHelper.getNamingScheme(annotation, ConfigFieldException::new)));
 		}
 	}
 

--- a/src/main/java/org/quiltmc/config/impl/util/NamingSchemeHelper.java
+++ b/src/main/java/org/quiltmc/config/impl/util/NamingSchemeHelper.java
@@ -16,6 +16,7 @@
 
 package org.quiltmc.config.impl.util;
 
+import org.quiltmc.config.api.annotations.DisplayNameConvention;
 import org.quiltmc.config.api.annotations.SerializedNameConvention;
 import org.quiltmc.config.api.metadata.NamingScheme;
 
@@ -41,6 +42,14 @@ public final class NamingSchemeHelper {
 			return annotation.value();
 		} else {
 			return this.createCustomNamingScheme(annotation.custom(), exceptionFactory);
+		}
+	}
+
+	public NamingScheme getNamingScheme(DisplayNameConvention annotation, BiFunction<String, Throwable, RuntimeException> exceptionFactory) {
+		if (annotation.custom().isEmpty()) {
+			return annotation.value();
+		} else {
+			return createCustomNamingScheme(annotation.custom(), exceptionFactory);
 		}
 	}
 

--- a/src/main/java/org/quiltmc/config/impl/util/NamingSchemeHelper.java
+++ b/src/main/java/org/quiltmc/config/impl/util/NamingSchemeHelper.java
@@ -49,7 +49,7 @@ public final class NamingSchemeHelper {
 		if (annotation.custom().isEmpty()) {
 			return annotation.value();
 		} else {
-			return createCustomNamingScheme(annotation.custom(), exceptionFactory);
+			return this.createCustomNamingScheme(annotation.custom(), exceptionFactory);
 		}
 	}
 


### PR DESCRIPTION
- `DisplayName(String value, translatable=false)`: The display name of a metadata holder. Applicable to configs, sections, and fields. Metadata processors (like config screens) may define generated translation keys taking precedence if it isn't translatable. If translatable is true, the value should be treated as a translation key
- `DisplayNameConvention(DefaultNamingSchemes value, custom="")`: The naming scheme used to derive the fallback display names of the metadata holder for config screens. `DisplayName` must take precedence, metadata processors (like config screens) may define generated translation keys taking precedence over `DisplayNameConvention`. Inheritable and applicable to configs, sections, and fields
- `ChangeWarning(metdata.ChangeWarning.Type value, customMessage="")`: Used to tell config screen libraries that a warning should be displayed before applying changes. The type can be `RequiresRestart`, `Unsafe`, `Experimental`, `CustomTranslatable`, or `Custom`. If it is `CustomTranslatable`, `customMessage` is used as a translation key. If it is `Custom`, `customMessage` is used as the raw message, but the metdata provider may define translation keys that take precedence.

Fixes #31, fixes #30 