### PR TITLE
add public methods for getting min and max on ranges

### DIFF
--- a/src/main/java/org/quiltmc/config/api/Constraint.java
+++ b/src/main/java/org/quiltmc/config/api/Constraint.java
@@ -93,6 +93,14 @@ public interface Constraint<T> {
 			this.comparator = comparator;
 		}
 
+		public T min() {
+			return this.min;
+		}
+
+		public T max() {
+			return this.max;
+		}
+
 		@Override
 		public Optional<String> test(T value) {
 			int minTest = this.comparator.compare(this.min, value);


### PR DESCRIPTION
without this, it's impossible for you to check the min and max of a tracked value

context:
this method in my mod
```java
	private static Option<Double> createOptional(TrackedValue<Float> trackedValue) {
		Constraint.Range<?> range = null;

		for (Constraint<?> c : trackedValue.constraints()) {
			if (c instanceof Constraint.Range<?> constraintRange) {
				range = constraintRange;
			}
		}

		if (range == null) {
			throw new RuntimeException("value must have float range constraint " + trackedValue);
		}

		return new Option<>(
				trackedValue.key().toString(),
				Option.constantTooltip(Text.empty()),
				(text, value) -> GameOptions.getGenericValueText(text, Text.translatable("options.multiplier", value)),
				new Option.IntRangeValueSet((int) range.min() * 10, (int) range.max() * 10).withModifier(i -> (double) i / 10.0, double_ -> (int) (double_ * 10.0)),
				Codec.doubleRange(range.min(), range.max()),
				(double) trackedValue.getDefaultValue(),
				value -> {
					trackedValue.setValue(value.floatValue());
				}
		);
	}
```

requires an access widener to work, and there should be a proper way to do this