### PR TITLE
Add JSON and JSON5 serializers

### DIFF
--- a/serializers-json5/build.gradle
+++ b/serializers-json5/build.gradle
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.quiltmc.parsers:json:0.2.1'
+	implementation 'org.quiltmc.parsers:json:0.3.0'
 	api rootProject
     testImplementation(platform("org.junit:junit-bom:5.9.1"))
     testImplementation("org.junit.jupiter:junit-jupiter")

--- a/serializers-json5/src/main/java/org/quiltmc/config/api/serializers/AbstractJsonSerializer.java
+++ b/serializers-json5/src/main/java/org/quiltmc/config/api/serializers/AbstractJsonSerializer.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2022-2024 QuiltMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.quiltmc.config.api.serializers;
+
+import org.quiltmc.config.api.Config;
+import org.quiltmc.config.api.Constraint;
+import org.quiltmc.config.api.MarshallingUtils;
+import org.quiltmc.config.api.annotations.Comment;
+import org.quiltmc.config.api.exceptions.ConfigParseException;
+import org.quiltmc.config.api.values.*;
+import org.quiltmc.config.impl.tree.TrackedValueImpl;
+import org.quiltmc.config.impl.util.SerializerUtils;
+import org.quiltmc.parsers.json.JsonReader;
+import org.quiltmc.parsers.json.JsonToken;
+import org.quiltmc.parsers.json.JsonWriter;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.*;
+
+/**
+ * A default serializer that writes in the <a href="https://json5.org/">JSON5 format</a>.
+ */
+public class AbstractJsonSerializer {
+	private void serialize(JsonWriter writer, Object value) throws IOException {
+		if (value instanceof Integer) {
+			writer.value((Integer) value);
+		} else if (value instanceof Long) {
+			writer.value((Long) value);
+		} else if (value instanceof Float) {
+			writer.value((Float) value);
+		} else if (value instanceof Double) {
+			writer.value((Double) value);
+		} else if (value instanceof Boolean) {
+			writer.value((Boolean) value);
+		} else if (value instanceof String) {
+			writer.value((String) value);
+		} else if (value instanceof BigInteger) {
+			writer.value((BigInteger) value);
+		} else if (value instanceof BigDecimal) {
+			writer.value((BigDecimal) value);
+		} else if (value instanceof ValueList<?>) {
+			writer.beginArray();
+
+			for (Object v : (ValueList<?>) value) {
+				serialize(writer, v);
+			}
+
+			writer.endArray();
+		} else if (value instanceof ValueMap<?>) {
+			writer.beginObject();
+
+			for (Map.Entry<String, ?> entry : (ValueMap<?>) value) {
+				writer.name(entry.getKey());
+				serialize(writer, entry.getValue());
+			}
+
+			writer.endObject();
+		} else if (value instanceof ConfigSerializableObject) {
+			serialize(writer, ((ConfigSerializableObject<?>) value).getRepresentation());
+		} else if (value == null) {
+			writer.nullValue();
+		} else if (value.getClass().isEnum()) {
+			writer.value(((Enum<?>) value).name());
+		} else {
+			throw new ConfigParseException();
+		}
+	}
+
+	private void serialize(JsonWriter writer, ValueTreeNode node) throws IOException {
+		for (String comment : node.metadata(Comment.TYPE)) {
+			writer.comment(comment);
+		}
+
+		if (node instanceof ValueTreeNode.Section) {
+			writer.name(node.key().getLastComponent());
+			writer.beginObject();
+
+			for (ValueTreeNode child : ((ValueTreeNode.Section) node)) {
+				serialize(writer, child);
+			}
+
+			writer.endObject();
+		} else {
+			TrackedValue<?> trackedValue = ((TrackedValue<?>) node);
+			Object defaultValue = trackedValue.getDefaultValue();
+
+			Optional<String> enumOptionsComment = SerializerUtils.createEnumOptionsComment(defaultValue);
+			if (enumOptionsComment.isPresent()) {
+				writer.comment(enumOptionsComment.get());
+			}
+
+			for (Constraint<?> constraint : trackedValue.constraints()) {
+				writer.comment(constraint.getRepresentation());
+			}
+
+			Optional<String> defaultComment = SerializerUtils.getDefaultValueString(defaultValue);
+			if (defaultComment.isPresent()) {
+				writer.comment("default: " + defaultComment.get());
+			}
+
+			String name = SerializerUtils.getSerializedName(trackedValue);
+			writer.name(name);
+
+			serialize(writer, trackedValue.getRealValue());
+		}
+	}
+
+	public void serialize(Config config, JsonWriter writer) throws IOException {
+		for (String comment : config.metadata(Comment.TYPE)) {
+			writer.comment(comment);
+		}
+
+		writer.beginObject();
+
+		for (ValueTreeNode node : config.nodes()) {
+			this.serialize(writer, node);
+		}
+
+		writer.endObject();
+		writer.close();
+	}
+
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	public void deserialize(Config config, JsonReader reader) {
+		try {
+			Map<String, Object> values = parseObject(reader);
+
+			for (TrackedValue<?> value : config.values()) {
+				Map<String, Object> m = values;
+				List<ValueKey> keyOptions = SerializerUtils.getPossibleKeys(config, value);
+
+				for (ValueKey key : keyOptions) {
+					for (int i = 0; i < key.length(); i++) {
+						String name = key.getKeyComponent(i);
+						if (m.containsKey(name) && i != key.length() - 1) {
+							m = (Map<String, Object>) m.get(name);
+						} else if (m.containsKey(name)) {
+							((TrackedValueImpl) value).setValue(MarshallingUtils.coerce(m.get(name), value.getDefaultValue(), (Map<String, ?> map, MarshallingUtils.MapEntryConsumer entryConsumer) ->
+								map.forEach(entryConsumer::put)), false);
+						}
+					}
+				}
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	private static Map<String, Object> parseObject(JsonReader reader) throws IOException {
+		reader.beginObject();
+
+		Map<String, Object> object = new LinkedHashMap<>();
+
+		while (reader.hasNext() && reader.peek() == JsonToken.NAME) {
+			object.put(reader.nextName(), parseElement(reader));
+		}
+
+		reader.endObject();
+
+		return object;
+	}
+
+	public static List<Object> parseArray(JsonReader reader) throws IOException {
+		reader.beginArray();
+
+		List<Object> array = new ArrayList<>();
+
+		while (reader.hasNext() && reader.peek() != JsonToken.END_ARRAY) {
+			array.add(parseElement(reader));
+		}
+
+		reader.endArray();
+
+		return array;
+	}
+
+	private static Object parseElement(JsonReader reader) throws IOException {
+		switch (reader.peek()) {
+			case END_ARRAY:
+				throw new ConfigParseException("Unexpected end of array");
+			case BEGIN_OBJECT:
+				return parseObject(reader);
+			case BEGIN_ARRAY:
+				return parseArray(reader);
+			case END_OBJECT:
+				throw new ConfigParseException("Unexpected end of object");
+			case NAME:
+				throw new ConfigParseException("Unexpected name");
+			case STRING:
+				return reader.nextString();
+			case NUMBER:
+				return reader.nextNumber();
+			case BOOLEAN:
+				return reader.nextBoolean();
+			case NULL:
+				reader.nextNull();
+				return null;
+			case END_DOCUMENT:
+				throw new ConfigParseException("Unexpected end of file");
+		}
+
+		throw new ConfigParseException("Encountered unknown JSON token");
+	}
+}

--- a/serializers-json5/src/main/java/org/quiltmc/config/api/serializers/AbstractJsonSerializer.java
+++ b/serializers-json5/src/main/java/org/quiltmc/config/api/serializers/AbstractJsonSerializer.java
@@ -34,7 +34,7 @@ import java.math.BigInteger;
 import java.util.*;
 
 /**
- * A default serializer that writes in the <a href="https://json5.org/">JSON5 format</a>.
+ * An abstract serializer that uses Quilt Parsers' JSON library in order to support JSON-like formats.
  */
 public class AbstractJsonSerializer {
 	private void serialize(JsonWriter writer, Object value) throws IOException {

--- a/serializers-json5/src/main/java/org/quiltmc/config/api/serializers/Json5Serializer.java
+++ b/serializers-json5/src/main/java/org/quiltmc/config/api/serializers/Json5Serializer.java
@@ -23,6 +23,9 @@ import org.quiltmc.parsers.json.JsonWriter;
 
 import java.io.*;
 
+/**
+ * A default serializer that writes in the <a href="https://json5.org/">JSON5 format</a>.
+ */
 public final class Json5Serializer extends AbstractJsonSerializer implements Serializer {
 	public static final Json5Serializer INSTANCE = new Json5Serializer();
 

--- a/serializers-json5/src/main/java/org/quiltmc/config/api/serializers/JsonCSerializer.java
+++ b/serializers-json5/src/main/java/org/quiltmc/config/api/serializers/JsonCSerializer.java
@@ -24,6 +24,9 @@ import org.quiltmc.parsers.json.JsonWriter;
 
 import java.io.*;
 
+/**
+ * A default serializer that writes in the <a href="https://code.visualstudio.com/docs/languages/json#_json-with-comments">JSON with Comments format</a>.
+ */
 public final class JsonCSerializer extends AbstractJsonSerializer implements Serializer {
 	public static final JsonCSerializer INSTANCE = new JsonCSerializer();
 

--- a/serializers-json5/src/main/java/org/quiltmc/config/api/serializers/JsonCSerializer.java
+++ b/serializers-json5/src/main/java/org/quiltmc/config/api/serializers/JsonCSerializer.java
@@ -18,28 +18,29 @@ package org.quiltmc.config.api.serializers;
 
 import org.quiltmc.config.api.Config;
 import org.quiltmc.config.api.Serializer;
+import org.quiltmc.parsers.json.JsonFormat;
 import org.quiltmc.parsers.json.JsonReader;
 import org.quiltmc.parsers.json.JsonWriter;
 
 import java.io.*;
 
-public final class Json5Serializer extends AbstractJsonSerializer implements Serializer {
-	public static final Json5Serializer INSTANCE = new Json5Serializer();
+public final class JsonCSerializer extends AbstractJsonSerializer implements Serializer {
+	public static final JsonCSerializer INSTANCE = new JsonCSerializer();
 
-	private Json5Serializer() {}
+	private JsonCSerializer() {}
 
 	@Override
 	public String getFileExtension() {
-		return "json5";
+		return "jsonc";
 	}
 
 	@Override
 	public void serialize(Config config, OutputStream to) throws IOException {
-		this.serialize(config, JsonWriter.json5(new OutputStreamWriter(to)));
+		this.serialize(config, JsonWriter.jsonc(new OutputStreamWriter(to)));
 	}
 
 	@Override
 	public void deserialize(Config config, InputStream from) {
-		this.deserialize(config, JsonReader.json5(new InputStreamReader(from)));
+		this.deserialize(config, JsonReader.create(new InputStreamReader(from), JsonFormat.JSONC));
 	}
 }

--- a/serializers-json5/src/main/java/org/quiltmc/config/api/serializers/JsonSerializer.java
+++ b/serializers-json5/src/main/java/org/quiltmc/config/api/serializers/JsonSerializer.java
@@ -23,6 +23,9 @@ import org.quiltmc.parsers.json.JsonWriter;
 
 import java.io.*;
 
+/**
+ * A default serializer that writes in the <a href="https://www.json.org/">JSON format</a>.
+ */
 public final class JsonSerializer extends AbstractJsonSerializer implements Serializer {
 	public static final JsonSerializer INSTANCE = new JsonSerializer();
 

--- a/serializers-json5/src/main/java/org/quiltmc/config/api/serializers/JsonSerializer.java
+++ b/serializers-json5/src/main/java/org/quiltmc/config/api/serializers/JsonSerializer.java
@@ -23,23 +23,23 @@ import org.quiltmc.parsers.json.JsonWriter;
 
 import java.io.*;
 
-public final class Json5Serializer extends AbstractJsonSerializer implements Serializer {
-	public static final Json5Serializer INSTANCE = new Json5Serializer();
+public final class JsonSerializer extends AbstractJsonSerializer implements Serializer {
+	public static final JsonSerializer INSTANCE = new JsonSerializer();
 
-	private Json5Serializer() {}
+	private JsonSerializer() {}
 
 	@Override
 	public String getFileExtension() {
-		return "json5";
+		return "json";
 	}
 
 	@Override
 	public void serialize(Config config, OutputStream to) throws IOException {
-		this.serialize(config, JsonWriter.json5(new OutputStreamWriter(to)));
+		this.serialize(config, JsonWriter.json(new OutputStreamWriter(to)));
 	}
 
 	@Override
 	public void deserialize(Config config, InputStream from) {
-		this.deserialize(config, JsonReader.json5(new InputStreamReader(from)));
+		this.deserialize(config, JsonReader.json(new InputStreamReader(from)));
 	}
 }

--- a/src/test/java/org/quiltmc/config/TestUtil.java
+++ b/src/test/java/org/quiltmc/config/TestUtil.java
@@ -16,9 +16,8 @@
 
 package org.quiltmc.config;
 
+import org.quiltmc.config.api.serializers.*;
 import org.quiltmc.config.implementor_api.ConfigEnvironment;
-import org.quiltmc.config.api.serializers.Json5Serializer;
-import org.quiltmc.config.api.serializers.TomlSerializer;
 
 import java.io.File;
 import java.io.IOException;
@@ -30,6 +29,8 @@ public class TestUtil {
 	public static final Path TEMP_DIR = Paths.get("temp");
 	public static final ConfigEnvironment TOML_ENV = new ConfigEnvironment(TestUtil.TEMP_DIR, TomlSerializer.INSTANCE);
 	public static final ConfigEnvironment JSON5_ENV = new ConfigEnvironment(TestUtil.TEMP_DIR, Json5Serializer.INSTANCE);
+	public static final ConfigEnvironment JSONC_ENV = new ConfigEnvironment(TestUtil.TEMP_DIR, JsonCSerializer.INSTANCE);
+	public static final ConfigEnvironment JSON_ENV = new ConfigEnvironment(TestUtil.TEMP_DIR, JsonSerializer.INSTANCE);
 
 	public static void deleteTempDir() throws IOException {
 		deleteDirectoryRecursively(TEMP_DIR.toFile());

--- a/src/test/java/org/quiltmc/config/old_wrapped/ConfigTest.java
+++ b/src/test/java/org/quiltmc/config/old_wrapped/ConfigTest.java
@@ -27,8 +27,7 @@ import org.quiltmc.config.api.exceptions.ConfigFieldException;
 import org.quiltmc.config.api.exceptions.TrackedValueException;
 import org.quiltmc.config.api.metadata.Comments;
 import org.quiltmc.config.api.metadata.MetadataType;
-import org.quiltmc.config.api.serializers.Json5Serializer;
-import org.quiltmc.config.api.serializers.TomlSerializer;
+import org.quiltmc.config.api.serializers.*;
 import org.quiltmc.config.api.values.TrackedValue;
 import org.quiltmc.config.api.values.ValueList;
 import org.quiltmc.config.api.values.ValueMap;
@@ -59,7 +58,7 @@ public class ConfigTest {
 
 	@BeforeAll
 	public static void initializeConfigDir() {
-		ENV = new ConfigEnvironment(TEMP, TomlSerializer.INSTANCE, Json5Serializer.INSTANCE);
+		ENV = new ConfigEnvironment(TEMP, TomlSerializer.INSTANCE, Json5Serializer.INSTANCE, JsonCSerializer.INSTANCE, JsonSerializer.INSTANCE);
 	}
 
 	@Test

--- a/src/test/java/org/quiltmc/config/reflective/AliasTest.java
+++ b/src/test/java/org/quiltmc/config/reflective/AliasTest.java
@@ -35,8 +35,18 @@ public class AliasTest extends AbstractConfigTest {
 	}
 
 	@Test
-	void testJson() throws IOException {
+	void testJson5() throws IOException {
 		test(TestUtil.JSON5_ENV);
+	}
+
+	@Test
+	void testJsonC() throws IOException {
+		test(TestUtil.JSONC_ENV);
+	}
+
+	@Test
+	void testJson() throws IOException {
+		test(TestUtil.JSON_ENV);
 	}
 
 	private static void test(ConfigEnvironment env) throws IOException {

--- a/src/test/java/org/quiltmc/config/reflective/ConfigTest.java
+++ b/src/test/java/org/quiltmc/config/reflective/ConfigTest.java
@@ -31,8 +31,7 @@ import org.quiltmc.config.api.exceptions.TrackedValueException;
 import org.quiltmc.config.api.metadata.Comments;
 import org.quiltmc.config.api.metadata.MetadataType;
 import org.quiltmc.config.api.metadata.NamingSchemes;
-import org.quiltmc.config.api.serializers.Json5Serializer;
-import org.quiltmc.config.api.serializers.TomlSerializer;
+import org.quiltmc.config.api.serializers.*;
 import org.quiltmc.config.api.values.TrackedValue;
 import org.quiltmc.config.api.values.ValueList;
 import org.quiltmc.config.api.values.ValueMap;
@@ -51,7 +50,7 @@ import java.util.Optional;
 
 @SuppressWarnings("deprecation")
 public class ConfigTest extends AbstractConfigTest {
-	static ConfigEnvironment ENV = new ConfigEnvironment(TestUtil.TEMP_DIR, TomlSerializer.INSTANCE, Json5Serializer.INSTANCE);
+	static ConfigEnvironment ENV = new ConfigEnvironment(TestUtil.TEMP_DIR, TomlSerializer.INSTANCE, Json5Serializer.INSTANCE, JsonCSerializer.INSTANCE, JsonSerializer.INSTANCE);
 
 	static TrackedValue<String> TEST;
 	static TrackedValue<Integer> TEST_INTEGER;

--- a/src/test/java/org/quiltmc/config/reflective/ReadWriteCycleTest.java
+++ b/src/test/java/org/quiltmc/config/reflective/ReadWriteCycleTest.java
@@ -49,6 +49,24 @@ public class ReadWriteCycleTest extends AbstractConfigTest {
 		this.matchConfigs(config, readConfig);
 	}
 
+	@Test
+	void testJsonCReadWriteCycle() {
+		TestReflectiveConfig config = ConfigFactory.create(TestUtil.JSONC_ENV, "testmod", "jsoncTestConfig", TestReflectiveConfig.class);
+		this.setUpConfig(config);
+
+		TestReflectiveConfig readConfig = ConfigFactory.create(TestUtil.JSONC_ENV, "testmod", "jsoncTestConfig", TestReflectiveConfig.class);
+		this.matchConfigs(config, readConfig);
+	}
+
+	@Test
+	void testJsonReadWriteCycle() {
+		TestReflectiveConfig config = ConfigFactory.create(TestUtil.JSON_ENV, "testmod", "jsonTestConfig", TestReflectiveConfig.class);
+		this.setUpConfig(config);
+
+		TestReflectiveConfig readConfig = ConfigFactory.create(TestUtil.JSON_ENV, "testmod", "jsonTestConfig", TestReflectiveConfig.class);
+		this.matchConfigs(config, readConfig);
+	}
+
 	/**
 	 * Sets a bunch of nonsense on the config so that it isn't default: if all values were default we wouldn't be able to tell if they were deserialized or not.
 	 */

--- a/src/test/java/org/quiltmc/config/reflective/TestSerializerEscaping.java
+++ b/src/test/java/org/quiltmc/config/reflective/TestSerializerEscaping.java
@@ -47,4 +47,26 @@ public class TestSerializerEscaping extends AbstractConfigTest {
 		Assertions.assertTrue(content.contains("\"gaming.awesome\":"), "File contents did not contain proper string key (expected '\"gaming.awesome\":')!\ncontents:\n" + content);
 		Assertions.assertTrue(content.contains("\"cool.awesome@list[]neat\":"), "File contents did not contain proper list key (expected '\"cool.awesome@list[]neat\":')!\ncontents:\n" + content);
 	}
+
+	@Test
+	void testJsonCReadWriteCycle() throws IOException {
+		TestEscapingConfig config = ConfigFactory.create(TestUtil.JSONC_ENV, "testmod", "jsoncEscapingTestConfig", TestEscapingConfig.class);
+		config.save();
+
+		String content = new String(Files.readAllBytes(TestUtil.TEMP_DIR.resolve("testmod").resolve("jsoncEscapingTestConfig.jsonc")));
+		Assertions.assertTrue(content.contains("\"servers.server.served\":"), "File contents did not contain proper map key (expected '\"servers.server.served\":')!\ncontents:\n" + content);
+		Assertions.assertTrue(content.contains("\"gaming.awesome\":"), "File contents did not contain proper string key (expected '\"gaming.awesome\":')!\ncontents:\n" + content);
+		Assertions.assertTrue(content.contains("\"cool.awesome@list[]neat\":"), "File contents did not contain proper list key (expected '\"cool.awesome@list[]neat\":')!\ncontents:\n" + content);
+	}
+
+	@Test
+	void testJsonReadWriteCycle() throws IOException {
+		TestEscapingConfig config = ConfigFactory.create(TestUtil.JSON_ENV, "testmod", "jsonEscapingTestConfig", TestEscapingConfig.class);
+		config.save();
+
+		String content = new String(Files.readAllBytes(TestUtil.TEMP_DIR.resolve("testmod").resolve("jsonEscapingTestConfig.json")));
+		Assertions.assertTrue(content.contains("\"servers.server.served\":"), "File contents did not contain proper map key (expected '\"servers.server.served\":')!\ncontents:\n" + content);
+		Assertions.assertTrue(content.contains("\"gaming.awesome\":"), "File contents did not contain proper string key (expected '\"gaming.awesome\":')!\ncontents:\n" + content);
+		Assertions.assertTrue(content.contains("\"cool.awesome@list[]neat\":"), "File contents did not contain proper list key (expected '\"cool.awesome@list[]neat\":')!\ncontents:\n" + content);
+	}
 }


### PR DESCRIPTION
This abstracts the JSON5 serializer in a way where support for JSON and JSONC can be easily added;
This also brings up a fix from Boring Default Game Rules (support for BigInteger and BigDecimal) for a crash that could be caused thanks to how JSON deserializing works (it's complicated)