### PR TITLE
Make `ReflectiveConfig.Section` implement `ValueTreeNode.Section`

### DIFF
--- a/src/main/java/org/quiltmc/config/api/InternalsHelper.java
+++ b/src/main/java/org/quiltmc/config/api/InternalsHelper.java
@@ -17,6 +17,8 @@
 package org.quiltmc.config.api;
 
 import org.jetbrains.annotations.ApiStatus;
+import org.quiltmc.config.api.values.ValueTreeNode;
+import org.quiltmc.config.impl.builders.ReflectiveConfigCreator;
 
 /**
  * Provides the implementation packages access to package-private methods. <strong>DO NOT USE THIS CLASS</strong>
@@ -29,5 +31,14 @@ public final class InternalsHelper {
 
 	public static <T extends ReflectiveConfig> void setWrappedConfig(T wrapped, Config config) {
 		wrapped.setWrappedConfig(config);
+		for (ValueTreeNode node : config.nodes()) {
+			if (node instanceof ValueTreeNode.Section) {
+				ValueTreeNode.Section section = (ValueTreeNode.Section) node;
+				ReflectiveConfigCreator.Reflective marker = section.metadata(ReflectiveConfigCreator.Reflective.TYPE);
+				if (marker != null) {
+					marker.self.setWrappedSection(section);
+				}
+			}
+		}
 	}
 }

--- a/src/main/java/org/quiltmc/config/api/InternalsHelper.java
+++ b/src/main/java/org/quiltmc/config/api/InternalsHelper.java
@@ -34,7 +34,7 @@ public final class InternalsHelper {
 		for (ValueTreeNode node : config.nodes()) {
 			if (node instanceof ValueTreeNode.Section) {
 				ValueTreeNode.Section section = (ValueTreeNode.Section) node;
-				ReflectiveConfigCreator.Reflective marker = section.metadata(ReflectiveConfigCreator.Reflective.TYPE);
+				ReflectiveConfigCreator.SectionMarker marker = section.metadata(ReflectiveConfigCreator.SectionMarker.TYPE);
 				if (marker != null) {
 					marker.self.setWrappedSection(section);
 				}

--- a/src/main/java/org/quiltmc/config/api/ReflectiveConfig.java
+++ b/src/main/java/org/quiltmc/config/api/ReflectiveConfig.java
@@ -18,6 +18,7 @@ package org.quiltmc.config.api;
 
 import org.quiltmc.config.api.metadata.MetadataType;
 import org.quiltmc.config.api.values.TrackedValue;
+import org.quiltmc.config.api.values.ValueKey;
 import org.quiltmc.config.api.values.ValueList;
 import org.quiltmc.config.api.values.ValueMap;
 import org.quiltmc.config.api.values.ValueTreeNode;
@@ -27,6 +28,7 @@ import org.quiltmc.config.impl.util.ConfigUtils;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -112,7 +114,9 @@ public abstract class ReflectiveConfig implements Config {
 		return new ValueMapBuilderImpl.TrackedValueMapBuilderImpl<>(defaultValue, this::value);
 	}
 
-	public static class Section {
+	public static class Section implements ValueTreeNode.Section {
+		private ValueTreeNode.Section wrapped;
+
 		public final <T> TrackedValue<T> value(T defaultValue) {
 			ConfigUtils.assertValueType(defaultValue);
 
@@ -126,6 +130,40 @@ public abstract class ReflectiveConfig implements Config {
 
 		public final <T> ValueMap.TrackedBuilder<T> map(T defaultValue) {
 			return new ValueMapBuilderImpl.TrackedValueMapBuilderImpl<>(defaultValue, this::value);
+		}
+
+		@Override
+		public ValueKey key() {
+			return this.wrapped.key();
+		}
+
+		@Override
+		public void propagateInheritedMetadata(Map<MetadataType<?, ?>, Object> inheritedMetadata) {
+			this.wrapped.propagateInheritedMetadata(inheritedMetadata);
+		}
+
+		@Override
+		public <M> M metadata(MetadataType<M, ?> type) {
+			return this.wrapped.metadata(type);
+		}
+
+		@Override
+		public <M> boolean hasMetadata(MetadataType<M, ?> type) {
+			return this.wrapped.hasMetadata(type);
+		}
+
+		@Override
+		public Map<MetadataType<?, ?>, Object> metadata() {
+			return this.wrapped.metadata();
+		}
+
+		@Override
+		public Iterator<ValueTreeNode> iterator() {
+			return this.wrapped.iterator();
+		}
+
+		final void setWrappedSection(ValueTreeNode.Section section) {
+			this.wrapped = section;
 		}
 	}
 }

--- a/src/main/java/org/quiltmc/config/impl/builders/ReflectiveConfigCreator.java
+++ b/src/main/java/org/quiltmc/config/impl/builders/ReflectiveConfigCreator.java
@@ -41,27 +41,27 @@ public class ReflectiveConfigCreator<C> implements Config.Creator {
 		this.creatorClass = creatorClass;
 	}
 
-	public static class Reflective {
-		public static MetadataType<Reflective, Builder> TYPE = MetadataType.create(Builder::new);
+	public static class SectionMarker {
+		public static MetadataType<SectionMarker, Builder> TYPE = MetadataType.create(Builder::new);
 		public final ReflectiveConfig.Section self;
 
-		private Reflective(ReflectiveConfig.Section self) {
+		private SectionMarker(ReflectiveConfig.Section self) {
 			this.self = self;
 		}
 
-		// HACK: ReadWriteCycleTest doesn't like that different instances of this aren't equal, so we just lie!
+		// ReadWriteCycleTest needs these to be equal
 		@Override
 		public boolean equals(Object obj) {
-			return true;
+			return obj instanceof SectionMarker && ((SectionMarker) obj).self.getClass().equals(this.self.getClass());
 		}
 
-		public static class Builder implements MetadataType.Builder<Reflective> {
+		public static class Builder implements MetadataType.Builder<SectionMarker> {
 			private ReflectiveConfig.Section self;
 
 			@Override
-			public ReflectiveConfigCreator.Reflective build() {
+			public ReflectiveConfigCreator.SectionMarker build() {
 				Objects.requireNonNull(this.self);
-				return new Reflective(this.self);
+				return new SectionMarker(this.self);
 			}
 		}
 	}
@@ -155,7 +155,7 @@ public class ReflectiveConfigCreator<C> implements Config.Creator {
 						}
 					}
 
-					b.metadata(Reflective.TYPE, metaBuilder -> metaBuilder.self = (ReflectiveConfig.Section) defaultValue);
+					b.metadata(SectionMarker.TYPE, metaBuilder -> metaBuilder.self = (ReflectiveConfig.Section) defaultValue);
 				});
 			} else if (defaultValue == null) {
 				throw new ConfigFieldException("Default value for field '" + field.getName() + "' cannot be null");


### PR DESCRIPTION
This fixes a holdover from the old WrappedConfig system which tried to hide the "internal" representations entirely.

Fixes #44

Passes tests but has not otherwise been tested.